### PR TITLE
Vectorize function calls

### DIFF
--- a/outlines/__init__.py
+++ b/outlines/__init__.py
@@ -1,4 +1,5 @@
 """Outlines is a Generative Model Programming Framework."""
+from outlines.base import vectorize
 from outlines.caching import clear_cache, disable_cache, get_cache
 from outlines.text import prompt
 
@@ -7,4 +8,5 @@ __all__ = [
     "disable_cache",
     "get_cache",
     "prompt",
+    "vectorize",
 ]

--- a/outlines/base.py
+++ b/outlines/base.py
@@ -1,0 +1,162 @@
+import asyncio
+import functools
+import inspect
+
+import numpy as np
+
+
+class vectorize:
+    """Returns an object that acts like a function but takes arrays as an input.
+
+    The vectorized function evaluates `func` over successive tuples of the input
+    chararrays and returns a single NumPy chararrays or a tuple of NumPy chararrays.
+
+    Its behavior is similar to NumPy's `vectorize` for Python functions: the function
+    being vectorized is executed in a `for` loop. Coroutines, however, are executed
+    concurrently.
+
+    Part of the code was adapted from `numpy.lib.function_base`.
+
+    """
+
+    def __init__(self, func, signature=None):
+        self.func = func
+        self.signature = signature
+        self.is_coroutine_fn = inspect.iscoroutinefunction(func)
+
+        functools.update_wrapper(self, func)
+
+        if self.signature is not None:
+            raise NotImplementedError(
+                "Vectorization of non-scalar functions is not implemented yet."
+            )
+
+    def __call__(self, *args, **kwargs):
+        """Call the vectorized function."""
+        if not args and not kwargs:
+            return self.call_thunk()
+        elif self.signature is not None:
+            return self.call_with_signature(*args, **kwargs)
+        else:
+            return self.call_no_signature(*args, **kwargs)
+
+    def call_thunk(self):
+        """Call a vectorized thunk.
+
+        Thunks have no arguments and can thus be called directly.
+
+        """
+        if self.is_coroutine_fn:
+            loop = asyncio.new_event_loop()
+            try:
+                outputs = loop.run_until_complete(self.func())
+            finally:
+                loop.close()
+        else:
+            outputs = self.func()
+
+        return outputs
+
+    def call_no_signature(self, *args, **kwargs):
+        """Call functions and coroutines when no signature is specified.
+
+        When no signature is specified we assume that all of the function's
+        inputs and outputs are scalars (core dimension of zero). We first
+        broadcast the input arrays, then iteratively apply the function over the
+        elements of the broadcasted arrays and finally reshape the results to
+        match the input shape.
+
+        Functions are executed in a for loop, coroutines are executed
+        concurrently.
+
+        """
+        # Convert args and kwargs to arrays
+        args = [np.array(arg) for arg in args]
+        kwargs = {key: np.array(value) for key, value in kwargs.items()}
+
+        # Broadcast args and kwargs
+        broadcast_shape = np.broadcast(*args, *list(kwargs.values())).shape
+        args = [np.broadcast_to(arg, broadcast_shape) for arg in args]
+        kwargs = {
+            key: np.broadcast_to(value, broadcast_shape)
+            for key, value in kwargs.items()
+        }
+
+        # Execute functions in a loop, and coroutines concurrently
+        if self.is_coroutine_fn:
+            outputs = self.vectorize_call_coroutine(broadcast_shape, args, kwargs)
+        else:
+            outputs = self.vectorize_call(broadcast_shape, args, kwargs)
+
+        # `outputs` is a flat array or a tuple of flat arrays. We reshape the arrays
+        # to match the input shape.
+        outputs = [
+            results if isinstance(results, tuple) else (results,) for results in outputs
+        ]
+        outputs = tuple(
+            [np.asarray(x).reshape(broadcast_shape).squeeze() for x in zip(*outputs)]
+        )
+        outputs = tuple([x.item() if np.ndim(x) == 0 else x for x in outputs])
+
+        n_results = len(list(outputs))
+
+        return outputs[0] if n_results == 1 else outputs
+
+    def vectorize_call(self, broadcast_shape, flat_args, flat_kwargs):
+        """Run the function in a for loop.
+
+        A possible extension would be to parallelize the calls.
+
+        Parameters
+        ----------
+        broadcast_shape
+            The brodcast shape of the input arrays.
+        flat_args
+            A flat array that contains the function's arguments.
+        flat_kwargs
+            A flat array that contains the function's keyword arguments.
+
+        """
+        outputs = []
+        for index in np.ndindex(*broadcast_shape):
+            args = tuple(arg[index] for arg in flat_args)
+            kwargs = {key: value[index] for key, value in flat_kwargs.items()}
+            outputs.append(self.func(*args, **kwargs))
+
+        return outputs
+
+    def vectorize_call_coroutine(self, broadcast_shape, args, kwargs):
+        """Run coroutines concurrently.
+
+        Creates as many tasks as needed and executes them in a new event
+        loop.
+
+        Parameters
+        ----------
+        broadcast_shape
+            The brodcast shape of the input arrays.
+        args
+            The function's broadcasted arguments.
+        kwargs
+            The function's broadcasted keyword arguments.
+
+        """
+
+        async def create_and_gather_tasks():
+            tasks = []
+            for index in np.ndindex(*broadcast_shape):
+                current_args = tuple(arg[index] for arg in args)
+                current_kwargs = {key: value[index] for key, value in kwargs.items()}
+                tasks.append(self.func(*current_args, **current_kwargs))
+
+            outputs = await asyncio.gather(*tasks)
+
+            return outputs
+
+        loop = asyncio.new_event_loop()
+        try:
+            outputs = loop.run_until_complete(create_and_gather_tasks())
+        finally:
+            loop.close()
+
+        return outputs

--- a/outlines/models/__init__.py
+++ b/outlines/models/__init__.py
@@ -5,7 +5,7 @@ completion, diffusers, etc.) and use routing functions everywhere else in the
 codebase.
 
 """
-from . import image_generation, text_completion
+from . import embeddings, image_generation, text_completion
 from .hf_diffusers import HuggingFaceDiffuser
 from .hf_transformers import HuggingFaceCompletion
 from .openai import OpenAICompletion, OpenAIEmbeddings, OpenAIImageGeneration

--- a/tests/models/test_hf_diffusers.py
+++ b/tests/models/test_hf_diffusers.py
@@ -1,3 +1,4 @@
+import numpy as np
 from PIL.Image import Image as PILImage
 
 from outlines.models.hf_diffusers import HuggingFaceDiffuser
@@ -12,7 +13,7 @@ def test_stable_diffusion():
     assert isinstance(image, PILImage)
 
     images = model("test", samples=3)
-    assert isinstance(images, list)
+    assert isinstance(images, np.ndarray)
     assert len(images) == 3
     for img in images:
         assert isinstance(image, PILImage)

--- a/tests/models/test_hf_transformers.py
+++ b/tests/models/test_hf_transformers.py
@@ -1,10 +1,7 @@
-import outlines
+import numpy as np
+import pytest
 
-outlines.disable_cache()
-
-import pytest  # noqa
-
-from outlines.models.hf_transformers import HuggingFaceCompletion  # noqa
+from outlines.models.hf_transformers import HuggingFaceCompletion
 
 TEST_MODEL = "hf-internal-testing/tiny-random-GPTJForCausalLM"
 
@@ -19,7 +16,7 @@ def test_samples():
     assert isinstance(answer, str)
 
     answers = model("test", samples=3)
-    assert isinstance(answers, list)
+    assert isinstance(answers, np.ndarray)
     assert len(answers) == 3
 
 

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,3 +1,5 @@
+import numpy as np
+import pytest
 from numpy.testing import assert_array_equal
 
 from outlines.base import vectorize
@@ -37,7 +39,7 @@ def test_vectorize_thunk():
     assert fn() == 1
 
 
-def test_vectorize_simple():
+def test_vectorize_scalar_simple():
     def passthrough(x):
         """A passthrough function."""
         return x
@@ -64,7 +66,7 @@ def test_vectorize_simple():
     assert_array_equal(out_array, [["one", "two"], ["three", "four"]])
 
 
-def test_vectorize_multiple_outputs():
+def test_vectorize_scalar_multiple_outputs():
     def passthrough_multiple_outputs(x):
         return x, x
 
@@ -84,7 +86,7 @@ def test_vectorize_multiple_outputs():
     assert_array_equal(out[1], ["one", "two", "three"])
 
 
-def test_vectorize_args():
+def test_vectorize_scalar_args():
     def passthrough_args(*args):
         """A passthrough function."""
         result = ""
@@ -118,7 +120,7 @@ def test_vectorize_args():
     assert_array_equal(out_array, [["one1", "two2"], ["three1", "four2"]])
 
 
-def test_vectorize_kwargs():
+def test_vectorize_scalar_kwargs():
     def passthrough_kwargs(**kwargs):
         """A passthrough function."""
         result = ""
@@ -150,3 +152,124 @@ def test_vectorize_kwargs():
     # Broadcasting
     out_array = fn(first=[["one", "two"], ["three", "four"]], second=["1", "2"])
     assert_array_equal(out_array, [["one1", "two2"], ["three1", "four2"]])
+
+
+def test_signature_invalid():
+    with pytest.raises(ValueError):
+        vectorize(lambda x: x, "(m,)->()")
+
+    with pytest.raises(TypeError, match="wrong number of positional"):
+        fn = vectorize(lambda x, y: x, "()->()")
+        fn(1, 2)
+
+    with pytest.raises(ValueError, match="wrong number of outputs"):
+
+        def test_multioutput(x, y):
+            return x, y
+
+        fn = vectorize(test_multioutput, "(),()->()")
+        fn(1, 2)
+
+
+def test_vectorize_simple():
+    def test(x):
+        return x
+
+    fn = vectorize(test, "(m)->(m)")
+    out = fn([["one", "two", "three"], ["four", "five", "six"]])
+    assert_array_equal(out, [["one", "two", "three"], ["four", "five", "six"]])
+
+    fn = vectorize(test, "()->()")
+    out = fn([["one", "two", "three"], ["four", "five", "six"]])
+    assert_array_equal(out, [["one", "two", "three"], ["four", "five", "six"]])
+
+
+def test_vectorize_kwargs():
+    def passthrough_kwargs(**kwargs):
+        """A passthrough function."""
+        result = ""
+        for _, value in kwargs.items():
+            result += value
+        return result
+
+    fn = vectorize(passthrough_kwargs, "(),()->()")
+
+    out_array = fn(first=["one", "two"], second=["1", "2"])
+    assert_array_equal(out_array, ["one1", "two2"])
+
+    # Broadcasting
+    out_array = fn(first=[["one", "two"], ["three", "four"]], second=["1", "2"])
+    assert_array_equal(out_array, [["one1", "two2"], ["three1", "four2"]])
+
+    async def passthrough_kwargs(**kwargs):
+        """A passthrough function."""
+        result = ""
+        for _, value in kwargs.items():
+            result += value
+        return result
+
+    fn = vectorize(passthrough_kwargs, "(),()->()")
+
+    out_array = fn(first=["one", "two"], second=["1", "2"])
+    assert_array_equal(out_array, ["one1", "two2"])
+
+    # Broadcasting
+    out_array = fn(first=[["one", "two"], ["three", "four"]], second=["1", "2"])
+    assert_array_equal(out_array, [["one1", "two2"], ["three1", "four2"]])
+
+
+def test_vectorize_reduce():
+    def test(x):
+        return x[0]
+
+    fn = vectorize(test, "(m)->()")
+    out = fn([["one", "two", "three"], ["four", "five", "six"]])
+    assert_array_equal(out, ["one", "four"])
+
+    fn = vectorize(test, "()->()")
+    out = fn([["one", "two", "three"], ["four", "five", "six"]])
+    assert_array_equal(out, [["o", "t", "t"], ["f", "f", "s"]])
+
+
+def test_vectorize_expand():
+    def test(x):
+        return np.array([x for i in range(3)])
+
+    fn = vectorize(test, "()->(s)")
+    out = fn(["one", "two"])
+    assert_array_equal(out, [["one", "one", "one"], ["two", "two", "two"]])
+
+
+def test_vectorize_coroutine_simple():
+    async def test(x):
+        return x
+
+    fn = vectorize(test, "(m)->(m)")
+    out = fn([["one", "two", "three"], ["four", "five", "six"]])
+    assert_array_equal(out, [["one", "two", "three"], ["four", "five", "six"]])
+
+    fn = vectorize(test, "()->()")
+    out = fn([["one", "two", "three"], ["four", "five", "six"]])
+    assert_array_equal(out, [["one", "two", "three"], ["four", "five", "six"]])
+
+
+def test_vectorize_coroutine_reduce():
+    async def test(x):
+        return x[0]
+
+    fn = vectorize(test, "(m)->()")
+    out = fn([["one", "two", "three"], ["four", "five", "six"]])
+    assert_array_equal(out, ["one", "four"])
+
+    fn = vectorize(test, "()->()")
+    out = fn([["one", "two", "three"], ["four", "five", "six"]])
+    assert_array_equal(out, [["o", "t", "t"], ["f", "f", "s"]])
+
+
+def test_vectorize_coroutine_expand():
+    async def test(x):
+        return np.array([x for i in range(3)])
+
+    fn = vectorize(test, "()->(s)")
+    out = fn(["one", "two"])
+    assert_array_equal(out, [["one", "one", "one"], ["two", "two", "two"]])

--- a/tests/test_base.py
+++ b/tests/test_base.py
@@ -1,0 +1,152 @@
+from numpy.testing import assert_array_equal
+
+from outlines.base import vectorize
+
+
+def test_vectorize_docstring():
+    def test(x):
+        """This is a test docstring"""
+        return x
+
+    fn = vectorize(test)
+    assert fn.__doc__ == "This is a test docstring"
+    assert fn.__name__ == "test"
+
+    async def test(x):
+        """This is a test docstring"""
+        return x
+
+    fn = vectorize(test)
+    assert fn.__doc__ == "This is a test docstring"
+    assert fn.__name__ == "test"
+
+
+def test_vectorize_thunk():
+    def thunk():
+        """A thunk"""
+        return 1
+
+    fn = vectorize(thunk)
+    assert fn() == 1
+
+    async def thunk():
+        """A thunk"""
+        return 1
+
+    fn = vectorize(thunk)
+    assert fn() == 1
+
+
+def test_vectorize_simple():
+    def passthrough(x):
+        """A passthrough function."""
+        return x
+
+    fn = vectorize(passthrough)
+
+    out_vector = fn(["one", "two", "three"])
+    assert_array_equal(out_vector, ["one", "two", "three"])
+
+    out_array = fn([["one", "two"], ["three", "four"]])
+    assert_array_equal(out_array, [["one", "two"], ["three", "four"]])
+
+    async def passthrough(x):
+        """A passthrough function."""
+        return x
+
+    fn = vectorize(passthrough)
+    assert fn.__doc__ == "A passthrough function."
+
+    out_vector = fn(["one", "two", "three"])
+    assert_array_equal(out_vector, ["one", "two", "three"])
+
+    out_array = fn([["one", "two"], ["three", "four"]])
+    assert_array_equal(out_array, [["one", "two"], ["three", "four"]])
+
+
+def test_vectorize_multiple_outputs():
+    def passthrough_multiple_outputs(x):
+        return x, x
+
+    fn = vectorize(passthrough_multiple_outputs)
+    out = fn(["one", "two", "three"])
+    assert len(out) == 2
+    assert_array_equal(out[0], ["one", "two", "three"])
+    assert_array_equal(out[1], ["one", "two", "three"])
+
+    async def passthrough_multiple_outputs(x):
+        return x, x
+
+    fn = vectorize(passthrough_multiple_outputs)
+    out = fn(["one", "two", "three"])
+    assert len(out) == 2
+    assert_array_equal(out[0], ["one", "two", "three"])
+    assert_array_equal(out[1], ["one", "two", "three"])
+
+
+def test_vectorize_args():
+    def passthrough_args(*args):
+        """A passthrough function."""
+        result = ""
+        for arg in args:
+            result += arg
+        return result
+
+    fn = vectorize(passthrough_args)
+
+    out_array = fn(["one", "two"], ["1", "2"])
+    assert_array_equal(out_array, ["one1", "two2"])
+
+    # Broadcasting
+    out_array = fn([["one", "two"], ["three", "four"]], ["1", "2"])
+    assert_array_equal(out_array, [["one1", "two2"], ["three1", "four2"]])
+
+    async def passthrough_args(*args):
+        """A passthrough function."""
+        result = ""
+        for arg in args:
+            result += arg
+        return result
+
+    fn = vectorize(passthrough_args)
+
+    out_array = fn(["one", "two"], ["1", "2"])
+    assert_array_equal(out_array, ["one1", "two2"])
+
+    # Broadcasting
+    out_array = fn([["one", "two"], ["three", "four"]], ["1", "2"])
+    assert_array_equal(out_array, [["one1", "two2"], ["three1", "four2"]])
+
+
+def test_vectorize_kwargs():
+    def passthrough_kwargs(**kwargs):
+        """A passthrough function."""
+        result = ""
+        for _, value in kwargs.items():
+            result += value
+        return result
+
+    fn = vectorize(passthrough_kwargs)
+
+    out_array = fn(first=["one", "two"], second=["1", "2"])
+    assert_array_equal(out_array, ["one1", "two2"])
+
+    # Broadcasting
+    out_array = fn(first=[["one", "two"], ["three", "four"]], second=["1", "2"])
+    assert_array_equal(out_array, [["one1", "two2"], ["three1", "four2"]])
+
+    async def passthrough_kwargs(**kwargs):
+        """A passthrough function."""
+        result = ""
+        for _, value in kwargs.items():
+            result += value
+        return result
+
+    fn = vectorize(passthrough_kwargs)
+
+    out_array = fn(first=["one", "two"], second=["1", "2"])
+    assert_array_equal(out_array, ["one1", "two2"])
+
+    # Broadcasting
+    out_array = fn(first=[["one", "two"], ["three", "four"]], second=["1", "2"])
+    assert_array_equal(out_array, [["one1", "two2"], ["three1", "four2"]])


### PR DESCRIPTION
In this PR I introduce a `outlines.vectorize` function that works similarly to `numpy.vectorize`, and allows to turn functions into functions that take arrays as an input. The major differences with `numpy.vectorize` are:

1. The possibility to batch the execution. Launching too many concurrent calls at the same time, doing inference locally with a batch size too large may not be acceptable and thus we need to batch the parallel calls.
2. It will execute coroutines concurrently for better performance.

This function will be used internally for model calls, so we can pass arrays of arbitrary shapes as inputs and get an array of answers. Usual broadcasting rules apply:

```python
import outlines.models as models

complete = models.text_completion.openai("text-davinci-003")

prompts = np.array([["Hi", "Hello"], ["Bye", "Ciao"]])
answer = complete(prompts)
print(answer.shape)
# (2, 2)

answer_samples = complete(prompts, num_samples=10)
print(answer_samples.shape)
# (2, 2, 10)
```

I made the choice here to execute the coroutines in a new event loop before returning. This allows to keep the synchronous user-facing API for now. Of course, this restricts the potential speedups we get by using `asyncio` and we will eventually need to move towards an explicitly async API. But that would be too big of a change for a single PR.

- [x] Vectorize scalar functions and coroutines (OpenAI API, simple tools)
- [x] Vectorize functions with an arbitrary signature (HF models)
- [x] Vectorize coroutines with an arbitrary signature (OpenAI with several samples)
- [x] Execute coroutines in a new event loop before returning
- [x] Replace the OpenAI calls with async ones and use `vectorize`
- [x] Use `vectorize` for HF model calls