### PR TITLE
Create masks from regex

### DIFF
--- a/outlines/models/hf_transformers.py
+++ b/outlines/models/hf_transformers.py
@@ -5,6 +5,7 @@ from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
 import numpy as np
 
 import outlines
+from outlines.text.masks import create_float_mask, create_int_mask
 
 if TYPE_CHECKING:
     import torch
@@ -331,16 +332,7 @@ def create_int_constraint(
     import torch
 
     num_prompt_tokens = prompt_tokens.shape[-1]
-
-    mask = torch.zeros(len(tokenizer), dtype=torch.bool)
-
-    for _, token_id in tokenizer.get_vocab().items():
-        token = tokenizer.decode(token_id)
-        are_all_digits = all([c.isdigit() for c in token])
-        if are_all_digits:
-            mask[token_id] = True
-
-    mask[tokenizer.eos_token_id] = False
+    mask = torch.from_numpy(create_int_mask(tokenizer.get_vocab()))
 
     def logit_processor(input_ids: torch.Tensor, scores: torch.Tensor) -> torch.Tensor:
         """Pre-process the model's output logits before generating the next token.
@@ -378,18 +370,7 @@ def create_float_constraint(
     import torch
 
     num_prompt_tokens = prompt_tokens.shape[-1]
-
-    mask = torch.zeros(len(tokenizer), dtype=torch.bool)
-
-    for _, token_id in tokenizer.get_vocab().items():
-        token = tokenizer.decode(token_id)
-        is_valid_float_or_int = (
-            all([c.isdigit() or c == "." for c in token]) and token.count(".") <= 1
-        )
-        if is_valid_float_or_int:
-            mask[token_id] = True
-
-    mask[tokenizer.eos_token_id] = False
+    mask = torch.from_numpy(create_float_mask(tokenizer.get_vocab()))
 
     def logit_processor(input_ids: torch.Tensor, scores: torch.Tensor) -> torch.Tensor:
         """Pre-process the model's output logits before generating the next token.

--- a/outlines/text/masks.py
+++ b/outlines/text/masks.py
@@ -1,0 +1,73 @@
+import re
+from typing import Dict, Iterable
+
+import numpy as np
+
+__all__ = [
+    "create_char_set_mask",
+    "create_float_mask",
+    "create_int_mask",
+    "create_mask_from_regex",
+]
+
+
+def create_mask_from_regex(vocabulary: Dict[str, int], regex: str) -> np.ndarray:
+    """Create a token mask from a regex.
+
+    Parameters
+    ----------
+    vocabulary
+        A dictionary that contains a tokenizer's vocabulary as a map
+        between tokens and their ids.
+    regex
+        The regex that tokens need to respect.
+
+    """
+    program = re.compile(regex)
+
+    mask = np.zeros(len(vocabulary), dtype=np.bool_)
+    for token, token_id in vocabulary.items():
+        if program.match(token) is not None:
+            mask[token_id] = True
+
+    return mask
+
+
+def create_int_mask(vocabulary: Dict[str, int]) -> np.ndarray:
+    """Create a mask to generate integers."""
+    mask = create_mask_from_regex(vocabulary, "^[0-9]+$")
+
+    return mask
+
+
+def create_float_mask(vocabulary: Dict[str, int]) -> np.ndarray:
+    """Create a mask to generate floating point numbers."""
+    mask = create_mask_from_regex(vocabulary, r"^([0-9]+([.][0-9]*)?|[.][0-9]+)$")
+
+    return mask
+
+
+def create_char_set_mask(
+    vocabulary: Dict[str, int], char_set: Iterable[str]
+) -> np.ndarray:
+    """Create a mask to only generate characters in a given set.
+
+    Parameters
+    ----------
+    vocabulary
+        A dictionary that contains a tokenizer's vocabulary as a map
+        between tokens and their ids.
+    char_set
+        An iterable that contains the valid single characters.
+
+    """
+    for char in char_set:
+        if len(char) != 1:
+            raise ValueError(
+                "The `char_set` argument of `char_set_mask` can only contain single characters."
+            )
+
+    char_set = re.escape("".join(char_set))
+    regex = "^[" + char_set + "]+$"
+    mask = create_mask_from_regex(vocabulary, regex)
+    return mask

--- a/tests/text/test_masks.py
+++ b/tests/text/test_masks.py
@@ -1,0 +1,69 @@
+import random
+
+import numpy as np
+import pytest
+from numpy.testing import assert_array_equal
+
+from outlines.text.masks import create_char_set_mask, create_float_mask, create_int_mask
+
+
+def test_int_mask():
+    vocabulary = {"1": 0, "12": 1, "12a": 2, "a1": 3, "1.3": 4}
+
+    mask = create_int_mask(vocabulary)
+    assert_array_equal(mask, np.array([True, True, False, False, False]))
+
+
+def test_float_mask():
+    vocabulary = {
+        "1": 0,
+        "12": 1,
+        "12a": 2,
+        "a1": 3,
+        "1.3": 4,
+        "1.": 5,
+        "0.": 6,
+        "1.2.3": 7,
+    }
+
+    mask = create_float_mask(vocabulary)
+    assert_array_equal(
+        mask, np.array([True, True, False, False, True, True, True, False])
+    )
+
+
+def test_char_set_mask():
+    vocabulary = {}
+    with pytest.raises(ValueError, match="single characters"):
+        create_char_set_mask(vocabulary, ["ab"])
+
+    vocabulary = {"a": 0, "ab": 1, "abc": 2, "1": 3, "1_a": 4}
+    mask = create_char_set_mask(vocabulary, ["a", "b", "1", "_"])
+    assert_array_equal(mask, np.array([True, True, False, True, True]))
+
+    vocabulary = {
+        "\\": 0,
+        "$": 1,
+        ".": 2,
+        "|": 3,
+        "?": 4,
+        "*": 5,
+        "(": 6,
+        ")": 7,
+        "[": 8,
+        "]": 9,
+        "{": 10,
+        "}": 11,
+    }
+
+    char_set = ["\\", "$", ".", "|", "?", "*", "(", ")", "[", "]", "{", "}"]
+    random.shuffle(char_set)
+
+    mask = create_char_set_mask(vocabulary, char_set)
+    assert_array_equal(mask, np.ones(12, dtype=np.bool_))
+
+    mask = create_char_set_mask(vocabulary, ["a"])
+    assert_array_equal(mask, np.zeros(12, dtype=np.bool_))
+
+    mask = create_char_set_mask(vocabulary, ["\n", "\r", "\t"])
+    assert_array_equal(mask, np.zeros(12, dtype=np.bool_))


### PR DESCRIPTION
This PR adds a function that creates a mask from strings that represent a regex. I also add a aliases for a few frequent use cases:

- floats
- integers
- set of characters

Masks are returned as boolean `np.ndarray`, and can thus be combined using `|` (logical or) and `&` (logical and):

```python
>>> import numpy as np
>>> a = np.array([True, False, True])
>>> b = np.array([True, True, False])
>>> a & b
array([ True, False, False])
>>> a | b
array([True, True, True])
```

I originally used `torch.tensor`s but decided to use `numpy.ndarray`s in the end. While this could allow supporting models written with different frameworks, I am still wondering if the conversion to and from the frameworks would slow down the generation due to copying the content of the arrays.

In the Numpy-> Framework direction, `jax.numpy.asarray` [does not  copy](https://jax.readthedocs.io/en/latest/_autosummary/jax.numpy.asarray.html) the input is a `numpy.ndarray`, and [neither does](https://pytorch.org/docs/stable/generated/torch.from_numpy.html) `torch.from_numpy`. So we should be able to return NumPy arrays here without adding any overhead.