### PR TITLE
Add retry mechanism for openai API calls

### DIFF
--- a/outlines/models/openai.py
+++ b/outlines/models/openai.py
@@ -184,8 +184,8 @@ def OpenAIEmbeddings(model_name: str):
     """
 
     @functools.partial(outlines.vectorize, signature="()->(s)")
-    def generate(query: str) -> np.ndarray:
-        api_response = call_embeddings_api(model_name, query)
+    async def generate(query: str) -> np.ndarray:
+        api_response = await call_embeddings_api(model_name, query)
         response = api_response["data"][0]["embedding"]
         return np.array(response)
 
@@ -213,8 +213,11 @@ def OpenAIImageGeneration(model_name: str = "", size: str = "512x512"):
 
     """
 
+    def generate(prompt: str, samples: int = 1):
+        return generate_base(prompt, samples)
+
     @functools.partial(outlines.vectorize, signature="(),()->(s)")
-    async def generate(prompt: str, samples: int = 1) -> PILImage:
+    async def generate_base(prompt: str, samples: int) -> PILImage:
         api_response = await call_image_generation_api(prompt, size, samples)
 
         images = []
@@ -381,13 +384,13 @@ async def call_chat_completion_api(
 @retry(**retry_config)
 @error_handler
 @cache
-def call_embeddings_api(
+async def call_embeddings_api(
     model: str,
     input: str,
 ):
     import openai
 
-    response = openai.Embedding.create(
+    response = await openai.Embedding.acreate(
         model=model,
         input=input,
     )
@@ -398,11 +401,11 @@ def call_embeddings_api(
 @retry(**retry_config)
 @error_handler
 @cache
-def call_image_generation_api(prompt: str, size: str, samples: int):
+async def call_image_generation_api(prompt: str, size: str, samples: int):
     import openai
 
-    response = openai.Image.create(
-        prompt=prompt, size=size, n=samples, response_format="b64_json"
+    response = await openai.Image.acreate(
+        prompt=prompt, size=size, n=int(samples), response_format="b64_json"
     )
 
     return response

--- a/outlines/models/openai.py
+++ b/outlines/models/openai.py
@@ -69,11 +69,14 @@ def OpenAICompletion(
         prompt: str,
         *,
         samples=1,
-        stop_at: List[Optional[str]] = [],
+        stop_at: Union[List[Optional[str]], str] = [],
         is_in=None,
         type=None,
     ):
         import tiktoken
+
+        if isinstance(stop_at, str):
+            stop_at = [stop_at]
 
         mask = {}
         if type is not None:

--- a/outlines/models/openai.py
+++ b/outlines/models/openai.py
@@ -228,7 +228,11 @@ def OpenAIImageGeneration(model_name: str = "", size: str = "512x512"):
             response = api_response["data"][i]["b64_json"]
             images.append(Image.open(BytesIO(base64.b64decode(response))))
 
-        return np.array(images, dtype="object")
+        array = np.empty((samples,), dtype="object")
+        for idx, image in enumerate(images):
+            array[idx] = image
+
+        return np.atleast_2d(array)
 
     return generate
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,7 @@ dependencies = [
    "perscache",
    "pydantic",
    "scipy",
+   "tenacity",
 ]
 dynamic = ["version"]
 
@@ -79,6 +80,7 @@ module = [
     "pydantic",
     "pytest",
     "scipy.*",
+    "tenacity.*",
     "tiktoken.*",
     "torch",
     "transformers",


### PR DESCRIPTION
Add retrying mechanism for openai api calls. 

Sample use cases
1. `complete = models.text_completion.openai("text-davinci-003", **{"wait_exponential_multiplier":1000, "wait_exponential_max":10000, "stop_max_attempt_number":5})`
2. `complete = models.text_completion.openai("text-davinci-003", **{"wait_random_min":1000, "wait_random_max":10000, "stop_max_attempt_number":5})`

Closes #115 

