### PR TITLE
Add basic parser-driven masking utilities

### DIFF
--- a/examples/parsing.py
+++ b/examples/parsing.py
@@ -1,0 +1,108 @@
+"""An example illustrating parser-based masking."""
+import math
+import time
+
+import torch
+from lark import Lark
+from lark.indenter import DedentError
+from lark.lexer import UnexpectedCharacters, UnexpectedToken
+from transformers import (
+    AutoModelForCausalLM,
+    AutoTokenizer,
+    LogitsProcessor,
+    LogitsProcessorList,
+    set_seed,
+)
+
+from outlines.text.parsing import PartialPythonIndenter, copy_parser_state, parse_to_end
+
+revision = None
+checkpoint = "Salesforce/codegen-350M-mono"
+device = "cuda"
+
+tokenizer = AutoTokenizer.from_pretrained(checkpoint)
+
+model = AutoModelForCausalLM.from_pretrained(
+    checkpoint, trust_remote_code=True, revision=revision
+).to(device)
+
+input_text = "def "
+inputs = tokenizer.encode(input_text, return_tensors="pt").to(device)
+
+
+class ParserLogitsProcessor(LogitsProcessor):
+    """Bias invalid token scores according to a running parse state."""
+
+    def __init__(self):
+        pyparser = Lark.open_from_package(
+            "lark",
+            "python.lark",
+            ["grammars"],
+            parser="lalr",
+            postlex=PartialPythonIndenter(),
+            start="file_input",
+        )
+        ip = pyparser.parse_interactive("")
+        self.parser_state = ip.parser_state
+        self.states_stack = [self.parser_state]
+        self.token_seq = None
+        self.token_idx = 0
+
+    def __call__(
+        self, input_ids: torch.LongTensor, scores: torch.FloatTensor
+    ) -> torch.FloatTensor:
+        if self.token_seq is None:
+            self.token_seq = tokenizer.decode(input_ids[0])
+            self.token_idx = len(input_ids[0]) - 1
+        else:
+            self.token_idx += 1
+            self.token_seq += tokenizer.decode(input_ids[0][self.token_idx])
+
+        # Process the last sampled token
+        lex_state = self.parser_state.lexer.state
+        lex_state.text = self.token_seq
+
+        self.parser_state, partial_tokens = parse_to_end(self.parser_state)
+
+        print("Parsed:\n")
+        print(self.token_seq)
+
+        print(partial_tokens)
+
+        mask = torch.full_like(scores, -math.inf)
+
+        # Determine which tokens in the vocabulary are valid next tokens
+        # given the parser state.
+        #
+        # TODO: This is a very naive and slow approach.  It could be done in
+        # parallel, but there are a few other approaches to try first, and
+        # those should dramatically reduce the amount of work done here.
+        t0 = time.perf_counter()
+        for test_token, token_id in tokenizer.vocab.items():
+            ps = copy_parser_state(self.parser_state)
+            ls = ps.lexer.state
+            ls.text = self.token_seq + test_token
+
+            try:
+                # TODO: The resulting states could possibly be reused?
+                parse_to_end(ps)
+                mask[0][token_id] = 0
+            except (UnexpectedToken, UnexpectedCharacters, DedentError):
+                pass
+
+        print(f"Next token masking duration: {time.perf_counter() - t0}")
+
+        return scores + mask
+
+
+set_seed(20399)
+
+outputs = model.generate(
+    inputs,
+    max_length=100,
+    temperature=0.1,
+    logits_processor=LogitsProcessorList([ParserLogitsProcessor()]),
+    renormalize_logits=True,
+)
+
+print(tokenizer.decode(outputs[0]))

--- a/outlines/text/parsing.py
+++ b/outlines/text/parsing.py
@@ -1,0 +1,240 @@
+from copy import copy
+from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Tuple
+
+import regex
+from lark.exceptions import (
+    LexError,
+    UnexpectedCharacters,
+    UnexpectedEOF,
+    UnexpectedToken,
+)
+from lark.indenter import PythonIndenter
+from lark.lexer import BasicLexer, LexerState, Scanner, Token
+from lark.parsers.lalr_interactive_parser import InteractiveParser
+from lark.utils import get_regexp_width
+
+if TYPE_CHECKING:
+    from lark.lexer import LexerThread
+    from lark.parsers.lalr_parser import ParserState
+
+
+class PartialTokenEOF(UnexpectedEOF):
+    pass
+
+
+class PartialScanner(Scanner):
+    def __init__(self, scanner: Scanner):
+        self.terminals = scanner.terminals
+        self.g_regex_flags = scanner.g_regex_flags
+        self.re_ = regex
+        self.use_bytes = scanner.use_bytes
+        self.match_whole = scanner.match_whole
+        self.allowed_types = scanner.allowed_types
+        self._mres = scanner._mres
+
+    def match(self, text, pos) -> Optional[Tuple[str, Optional[str], bool]]:
+        for mre in self._mres:
+            m = mre.match(text, pos=pos, partial=True)
+            if m:  # and ((not m.partial) or m.endpos == len(text)):
+                return m.group(0), m.lastgroup, m.partial
+        return None
+
+
+class PartialBasicLexer(BasicLexer):
+    def __init__(self, basic_lexer: BasicLexer):
+        self.re = regex
+        self.newline_types = basic_lexer.newline_types
+        self.ignore_types = basic_lexer.ignore_types
+        self.terminals = basic_lexer.terminals
+        self.user_callbacks = basic_lexer.user_callbacks
+        self.g_regex_flags = basic_lexer.g_regex_flags
+        self.use_bytes = basic_lexer.use_bytes
+        self.terminals_by_name = basic_lexer.terminals_by_name
+        self.callback = getattr(basic_lexer, "callback", None)
+
+        if basic_lexer._scanner is not None:
+            self._scanner: Optional[PartialScanner] = PartialScanner(
+                basic_lexer._scanner
+            )
+        else:
+            self._scanner = None
+
+        # This is used to determine the token type for partial matches
+        self.terminal_to_regex = {}
+        for name, terminal in self.terminals_by_name.items():
+            self.terminal_to_regex[name] = self.re.compile(
+                terminal.pattern.to_regexp(), self.g_regex_flags
+            )
+
+    def _build_scanner(self):
+        super()._build_scanner()
+        self._scanner = PartialScanner(self._scanner)
+
+    def partial_matches(self, value, type_):
+        partial_matches = set()
+
+        # TODO: It's unfortunate that we have to do this costly search (again).
+        # It would be better if we could *not* short-circuit the first time we
+        # scan in the call to `self.match`.
+        for term_name, term_regex in self.terminal_to_regex.items():
+            if term_name == type_:
+                # A standard lexed token result could actual indicate a partial
+                # match
+                regex_min, regex_max = get_regexp_width(term_regex.pattern)
+                if regex_min <= len(value) < regex_max:
+                    partial_matches.add(term_name)
+            else:
+                m = term_regex.match(value, partial=True)
+                if m:
+                    partial_matches.add(term_name)
+
+        return partial_matches
+
+    def next_token(self, lex_state: LexerState, parser_state: Any = None) -> Token:
+        line_ctr = lex_state.line_ctr
+        while line_ctr.char_pos < len(lex_state.text):
+            res = self.match(lex_state.text, line_ctr.char_pos)
+
+            if not res:
+                allowed = self.scanner.allowed_types - self.ignore_types
+                if not allowed:
+                    allowed = {"<END-OF-FILE>"}
+                raise UnexpectedCharacters(
+                    lex_state.text,
+                    line_ctr.char_pos,
+                    line_ctr.line,
+                    line_ctr.column,
+                    allowed=allowed,
+                    token_history=lex_state.last_token and [lex_state.last_token],
+                    state=parser_state,
+                    terminals_by_name=self.terminals_by_name,
+                )
+
+            value, type_, partial = res
+
+            # Don't advance the lexing state if we're at the end; there could
+            # be ambiguous token types that aren't finished.
+            if line_ctr.char_pos + len(value) >= len(lex_state.text):
+                partial_matches = self.partial_matches(value, type_)
+                if partial_matches or partial:
+                    raise PartialTokenEOF(partial_matches)
+
+            assert isinstance(self.callback, Dict)
+
+            if type_ not in self.ignore_types:
+                t = Token(
+                    type_, value, line_ctr.char_pos, line_ctr.line, line_ctr.column
+                )
+                line_ctr.feed(value, type_ in self.newline_types)
+                t.end_line = line_ctr.line
+                t.end_column = line_ctr.column
+                t.end_pos = line_ctr.char_pos
+                if t.type in self.callback:
+                    t = self.callback[t.type](t)
+                    if not isinstance(t, Token):
+                        raise LexError(
+                            "Callbacks must return a token (returned %r)" % t
+                        )
+                lex_state.last_token = t
+                return t
+
+            if type_ in self.callback:
+                t2 = Token(
+                    type_, value, line_ctr.char_pos, line_ctr.line, line_ctr.column
+                )
+                self.callback[type_](t2)
+
+            line_ctr.feed(value, type_ in self.newline_types)
+
+        raise EOFError(self)
+
+
+class PartialPythonIndenter(PythonIndenter):
+    """An `Indenter` that doesn't reset its state every time `process` is called."""
+
+    def process(self, stream):
+        return self._process(stream)
+
+    def _process(self, stream):
+        for token in stream:
+            # These were previously *after* the `yield`, but that makes the
+            # state tracking unnecessarily convoluted.
+            if token.type in self.OPEN_PAREN_types:
+                self.paren_level += 1
+            elif token.type in self.CLOSE_PAREN_types:
+                self.paren_level -= 1
+                if self.paren_level < 0:
+                    raise UnexpectedToken(token, [])
+
+            if token.type == self.NL_type:
+                yield from self.handle_NL(token)
+            else:
+                yield token
+
+        # while len(self.indent_level) > 1:
+        #     self.indent_level.pop()
+        #     yield Token(self.DEDENT_type, "")
+
+    def __copy__(self):
+        res = type(self)()
+        res.paren_level = self.paren_level
+        res.indent_level = copy(self.indent_level)
+        return res
+
+
+def copy_lexer_thread(lexer_thread: "LexerThread") -> "LexerThread":
+    res = copy(lexer_thread)
+    res.lexer = copy(res.lexer)
+
+    if (
+        res.lexer.postlexer
+        and isinstance(res.lexer.postlexer, PythonIndenter)
+        and not isinstance(res.lexer.postlexer, PartialPythonIndenter)
+    ):
+        # Patch these methods so that the post lexer keeps its state
+        # XXX: This won't really work in generality.
+        postlexer = PartialPythonIndenter()
+        postlexer.paren_level = res.lexer.postlexer.paren_level
+        postlexer.indent_level = res.lexer.postlexer.indent_level
+        res.lexer.postlexer = postlexer
+
+    # Patch/replace the lexer objects so that they support partial matches
+    lexer = res.lexer.lexer
+    if not isinstance(lexer.root_lexer, PartialBasicLexer):
+        lexer.root_lexer = PartialBasicLexer(lexer.root_lexer)
+
+        basic_lexers = res.lexer.lexer.lexers
+        for idx, lexer in basic_lexers.items():
+            basic_lexers[idx] = PartialBasicLexer(lexer)
+
+    res.lexer.postlexer = copy(res.lexer.postlexer)
+
+    return res
+
+
+def copy_parser_state(parser_state: "ParserState") -> "ParserState":
+    res = copy(parser_state)
+    res.lexer = copy_lexer_thread(res.lexer)
+
+    return res
+
+
+def copy_ip(ip: "InteractiveParser") -> "InteractiveParser":
+    res = copy(ip)
+    res.lexer_thread = copy_lexer_thread(res.lexer_thread)
+    return res
+
+
+def parse_to_end(parser_state: "ParserState") -> Tuple["ParserState", Set[str]]:
+    """Continue parsing from the current parse state and return partial next tokens."""
+
+    parser_state = copy_parser_state(parser_state)
+
+    expected_next_tokens: Set[str] = set()
+    try:
+        for token in parser_state.lexer.lex(parser_state):
+            parser_state.feed_token(token)
+    except PartialTokenEOF as e:
+        expected_next_tokens = e.expected
+
+    return parser_state, expected_next_tokens

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,8 @@ test = [
     "transformers",
     "coverage[toml]>=5.1",
     "diff-cover",
+    "lark",
+    "regex",
 ]
 
 [project.urls]
@@ -87,6 +89,8 @@ module = [
     "tiktoken.*",
     "torch",
     "transformers.*",
+    "lark.*",
+    "regex.*",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ test = [
     "diff-cover",
     "lark",
     "regex",
+    "interegular",
 ]
 
 [project.urls]
@@ -91,6 +92,7 @@ module = [
     "transformers.*",
     "lark.*",
     "regex.*",
+    "interegular.*",
 ]
 ignore_missing_imports = true
 

--- a/tests/text/test_parsing.py
+++ b/tests/text/test_parsing.py
@@ -1,8 +1,19 @@
+import interegular
+import pytest
 from lark import Lark
 from lark.indenter import DedentError
 from lark.lexer import UnexpectedCharacters, UnexpectedToken
 
-from outlines.text.parsing import PartialPythonIndenter, copy_parser_state, parse_to_end
+from outlines.text.parsing import (
+    PartialPythonIndenter,
+    copy_parser_state,
+    create_pmatch_parser_states,
+    find_partial_matches,
+    map_partial_states_to_vocab,
+    parse_to_end,
+    terminals_to_fsms,
+    terminals_to_lalr_states,
+)
 
 
 def test_parse_to_end():
@@ -111,3 +122,156 @@ def test_sequential_parse_example():
             assert input_tokens[i + 1] in next_vocab
         else:
             assert all(tk in next_vocab for tk in ["\n", "\nde", "  ", " + 1"])
+
+
+def test_partial_match():
+    name_pattern = interegular.parse_pattern(r"[^\W\d]\w*")
+    name_fsm = name_pattern.to_fsm()
+
+    def_pattern = interegular.parse_pattern("def")
+    def_fsm = def_pattern.to_fsm()
+
+    assert find_partial_matches(def_fsm, "def") == {(2, (1, 2, 3))}
+    assert find_partial_matches(def_fsm, "de") == {(None, (1, 2))}
+    assert find_partial_matches(def_fsm, "d") == {(None, (1,))}
+    assert find_partial_matches(def_fsm, "") == set()
+    assert find_partial_matches(def_fsm, "df") == set()
+    assert find_partial_matches(def_fsm, "ef") == {(1, (2, 3))}
+    assert find_partial_matches(def_fsm, "e") == {(None, (2,))}
+    assert find_partial_matches(def_fsm, "f") == {(0, (3,))}
+    assert find_partial_matches(def_fsm, "ef foo") == {(1, (2, 3))}
+
+    # This string has a `DEF` token in it, but should ultimately not lex one
+    assert find_partial_matches(def_fsm, "defb") == {(2, (1, 2, 3))}
+
+    # `NAME` can have multiple start states for this input
+    assert find_partial_matches(name_fsm, "d") == {(0, (1,)), (0, (2,))}
+    # Not this case
+    assert find_partial_matches(name_fsm, "1d") == {(1, (2, 2))}
+
+    assert find_partial_matches(name_fsm, "blah") == {
+        (3, (1, 2, 2, 2)),
+        (3, (2, 2, 2, 2)),
+    }
+
+
+def test_partial_match_preprocessing():
+    pyparser = Lark.open_from_package(
+        "lark",
+        "python.lark",
+        ["grammars"],
+        parser="lalr",
+        postlex=PartialPythonIndenter(),
+        start="file_input",
+    )
+
+    symbol_names_and_fsms = terminals_to_fsms(pyparser)
+    test_symbols = {"DEF", "NAME", "__IGNORE_0"}
+    symbol_names_and_fsms = {
+        k: v for k, v in symbol_names_and_fsms.items() if k in test_symbols
+    }
+
+    vocabulary = {"d", "e", "ef foo", "f ", " "}
+
+    pstate_to_vocab = map_partial_states_to_vocab(
+        vocabulary, symbol_names_and_fsms, False
+    )
+
+    assert dict(pstate_to_vocab) == {
+        ("NAME", 1): {"d", "e", "ef foo", "f "},
+        ("NAME", 2): {"d", "e", "ef foo", "f "},
+        ("DEF", 1): {
+            "d",
+        },
+        ("DEF", 2): {"e", "ef foo"},
+        ("DEF", 3): {
+            "f ",
+        },
+        ("__IGNORE_0", 1): {
+            " ",
+        },
+        ("__IGNORE_0", 2): {
+            " ",
+        },
+    }
+
+    pstate_to_vocab = map_partial_states_to_vocab(
+        vocabulary, symbol_names_and_fsms, True
+    )
+
+    assert dict(pstate_to_vocab) == {
+        ("DEF", 1): {"e", "ef foo"},
+        ("DEF", 2): {
+            "f ",
+        },
+        ("DEF", 0): {
+            "d",
+        },
+        ("NAME", 1): {"d", "e", "ef foo", "f "},
+        ("NAME", 2): {"d", "e", "ef foo", "f "},
+        ("NAME", 0): {"d", "e", "ef foo", "f "},
+        ("__IGNORE_0", 1): {
+            " ",
+        },
+        ("__IGNORE_0", 2): {
+            " ",
+        },
+        ("__IGNORE_0", 0): {
+            " ",
+        },
+    }
+
+
+def test_parse_from_partial_match():
+    """Make sure we can continue parsing from an FSM-based partial match."""
+    pyparser = Lark(
+        r"""
+start: funcdef
+
+funcdef: "def" name "(" ")" ":"
+
+%ignore /[\t \f]+/  // WS
+
+!name: NAME | "match" | "case"
+NAME: /[^\W\d]\w*/
+
+    """,
+        parser="lalr",
+        postlex=PartialPythonIndenter(),
+    )
+
+    terminals_to_states = terminals_to_lalr_states(pyparser)
+    symbol_names_and_fsms = terminals_to_fsms(pyparser)
+
+    term_type = "DEF"
+    def_fsm = symbol_names_and_fsms[term_type]
+
+    # TODO FIXME: This is broken, and it's a bug in `lark`'s Python grammar!
+    # ptoken = "defx"
+
+    ptoken = "ef foo"
+    pmatch = find_partial_matches(def_fsm, ptoken)
+    first_pmatch = next(pm for pm in pmatch if pm[0] is not None)
+    (parser_state,) = create_pmatch_parser_states(
+        pyparser, terminals_to_states, term_type, ptoken, first_pmatch
+    )
+    new_parser_state, expected_next_tokens = parse_to_end(parser_state)
+    assert expected_next_tokens == {"NAME"}
+
+    ptoken = "ef foo():"
+    pmatch = find_partial_matches(def_fsm, ptoken)
+    first_pmatch = next(pm for pm in pmatch if pm[0] is not None)
+    (parser_state,) = create_pmatch_parser_states(
+        pyparser, terminals_to_states, term_type, ptoken, first_pmatch
+    )
+    new_parser_state, expected_next_tokens = parse_to_end(parser_state)
+    assert not expected_next_tokens
+
+    ptoken = "ef ("
+    pmatch = find_partial_matches(def_fsm, ptoken)
+    first_pmatch = next(pm for pm in pmatch if pm[0] is not None)
+    (parser_state,) = create_pmatch_parser_states(
+        pyparser, terminals_to_states, term_type, ptoken, first_pmatch
+    )
+    with pytest.raises(UnexpectedToken):
+        parse_to_end(parser_state)

--- a/tests/text/test_parsing.py
+++ b/tests/text/test_parsing.py
@@ -1,0 +1,113 @@
+from lark import Lark
+from lark.indenter import DedentError
+from lark.lexer import UnexpectedCharacters, UnexpectedToken
+
+from outlines.text.parsing import PartialPythonIndenter, copy_parser_state, parse_to_end
+
+
+def test_parse_to_end():
+    pyparser = Lark.open_from_package(
+        "lark",
+        "python.lark",
+        ["grammars"],
+        parser="lalr",
+        postlex=PartialPythonIndenter(),
+        start="file_input",
+    )
+
+    ip = pyparser.parse_interactive("x")
+    parser_state, expected_next_tokens = parse_to_end(ip.parser_state)
+    assert not parser_state.value_stack
+    assert expected_next_tokens == {"NAME"}
+
+    ip = pyparser.parse_interactive("x = '")
+    parser_state, expected_next_tokens = parse_to_end(ip.parser_state)
+    assert parser_state.value_stack[-1].type == "EQUAL"
+    assert expected_next_tokens == {"LONG_STRING", "STRING"}
+
+    ip = pyparser.parse_interactive("x = 'hi")
+    parser_state, expected_next_tokens = parse_to_end(ip.parser_state)
+    assert parser_state.value_stack[-1].type == "EQUAL"
+    assert expected_next_tokens == {"STRING"}
+
+    ip = pyparser.parse_interactive("x = ('hi")
+    parser_state, expected_next_tokens = parse_to_end(ip.parser_state)
+    assert parser_state.value_stack[-1].type == "LPAR"
+    assert expected_next_tokens == {"STRING"}
+
+    ip = pyparser.parse_interactive("def")
+    parser_state, expected_next_tokens = parse_to_end(ip.parser_state)
+    assert not parser_state.value_stack
+    assert expected_next_tokens == {"NAME", "DEF"}
+
+    # Now, try something incremental
+    parser_state = copy_parser_state(parser_state)
+    last_lexer_state = parser_state.lexer.state
+    last_lexer_state.text = "def blah()"
+
+    (parser_state, expected_next_tokens) = parse_to_end(parser_state)
+
+    last_lexer_state = parser_state.lexer.state
+    last_valid_token = last_lexer_state.last_token
+    assert last_valid_token.type == "RPAR"
+    assert not expected_next_tokens
+
+
+def test_sequential_parse_example():
+    input_tokens = [
+        "x ",
+        "= ",
+        "1",
+        "\nde",
+        "f ",
+        "foo(",
+        "x)",
+        ":\n",
+        "  ",
+        "  return x",
+        " + 1",
+        "\n",
+        "z ",
+        "= ",
+        "foo(",
+        '"hi' '")',
+    ]
+    vocab = set(input_tokens)
+
+    pyparser = Lark.open_from_package(
+        "lark",
+        "python.lark",
+        ["grammars"],
+        parser="lalr",
+        postlex=PartialPythonIndenter(),
+        start="file_input",
+    )
+    ip = pyparser.parse_interactive("")
+    parser_state = ip.parser_state
+
+    token_seq = ""
+    for i, token in enumerate(input_tokens):
+        token_seq += token
+
+        lex_state = parser_state.lexer.state
+        lex_state.text = token_seq
+
+        parser_state, partial_tokens = parse_to_end(parser_state)
+
+        next_vocab = set()
+        for test_token in vocab:
+            ps = copy_parser_state(parser_state)
+            ls = ps.lexer.state
+            ls.text = token_seq + test_token
+
+            try:
+                # TODO: The resulting states could possibly be reused?
+                parse_to_end(ps)
+                next_vocab.add(test_token)
+            except (UnexpectedToken, UnexpectedCharacters, DedentError):
+                pass
+
+        if i + 1 < len(input_tokens):
+            assert input_tokens[i + 1] in next_vocab
+        else:
+            assert all(tk in next_vocab for tk in ["\n", "\nde", "  ", " + 1"])


### PR DESCRIPTION
This PR introduces utilities for parser-driven masking: i.e. a parser is run alongside a language model's (LM) token sampling step and used to filter for grammar-valid next tokens.  `lark` was chosen as the underlying parser library because I have previous experience using it, its design is fairly straightforward, it's pure Python, and it supports arbitrary EBNF-like grammars.

The current approach is very experimental and is essentially driven by some patches to `lark`'s LALR parser.  Those patches allow for incremental additions to a lexed/parsed string, and, more importantly, they allow for partial token matches during scanning.  Partial tokens arise when the string being scanned cuts off without completely constructing/finalizing a token.  

For example, the source string `"def fo"` would normally be scanned into two tokens `def` and `fo`; however, if the next LM-sampled token is `"o("`, the complete sampled source string would be `"def foo("`, and the parsed result would be the tokens `def`, `foo`, `(`.  These two scan (or parse) results conflict, because the first one ends by assuming that `fo` is a completed name token, but the next result&mdash;when starting from the beginning&mdash;contains no such token.  In other words, we would need to backtrack in order to find the "correct" name token (i.e. `foo`).

The approach currently used in this PR doesn't immediately accept (i.e. advance the parse state) scan results from tokens with ambiguities like that.

- [ ] Create a demo that uses the new `Sequence` functionality.
- [x] Use the partial token matching information to improve next-token filtering.
- [ ] We could use a better partial matching approach.  The current one does partial matching for only the first terminal regex in a regex that's the _union_ of many terminals, then it follows up with a loop that checks each terminal regex in that union.
- [ ] See if we can expand regex and multi-character terminal symbols in a context-free grammar (CFG) and create more "granular" CFGs that accept characters at a time.  This would make the generated lexers and parsers immediately compatible with single-character-at-a-time parsing and provide a more general and less hacky solution to our partial matching/parsing problem.  It would also provide a foundation for the pre-computing described below.
    The basic idea is that we can get finite state machines (FSMs) for all the (actually regular) regex and multi-character terminal symbols, and those FSMs can be converted to symbols and rules that themselves can be added to the parent CFG.
- [ ] Look into pre-computing token-based subsets of a vocabulary (e.g. subsets of the vocabulary that are valid [partial] `NAME`/`DEF`/etc. token matches).  
    In general, all the vocabulary tokens/strings could possibly be grouped and classified in such a way that the "run-time" parsing only needs to be performed on much smaller sets.  
    For example, a vocabulary token like `"foo("` could be parsed offline to determine that the `"foo"` part is/could be a [partial] `NAME` token, and the `"("` a subsequent `LPAR` token, of course.  With that information we could create a subset of the vocabulary that is `NAME`-prefixed, then, when the current parse state only permits a transition to a `NAME` token, we can reduce the filtered/checked vocabulary to only that subset (or simply reduce/refine the support in rejection sampling scenarios).
    [Here's a Gist outlining the idea](https://gist.github.com/brandonwillard/4567b124596835c0dec31df7cd094da8).  A `lark` grammar that relies less on non-standard/regular regex features, like [this SQL one](https://github.com/zbrookle/sql_to_ibis/blob/0e9226da42065940ce21439d490f9fcacadc7f92/sql_to_ibis/grammar/sql.lark), could actually work with the very naive approach implemented in that Gist.  Again, we want as much coverage as we can get out of the box, but, if people are willing to tweak a grammar, we could pre-process vocabularies right now.
- [ ] Do something better for the indentation-tracking patch.
- [ ] Can we use tree-sitter instead?  I tried out the Python bindings, but they appeared to be lacking wrt. grammar information and lexer/scanner exposure.