### PR TITLE
Fix vectorization of `transformers` models

### DIFF
--- a/tests/models/test_hf_transformers.py
+++ b/tests/models/test_hf_transformers.py
@@ -20,16 +20,36 @@ def test_samples():
     assert len(answers) == 3
 
 
+def test_prompt_array():
+    model = HuggingFaceCompletion(TEST_MODEL, max_tokens=10)
+    prompts = [["Hello", "Bonjour"], ["Ciao", "Hallo"]]
+    answers = model(prompts)
+    assert isinstance(answers, np.ndarray)
+    assert answers.shape == (2, 2)
+
+    answers = model(prompts, samples=5)
+    assert isinstance(answers, np.ndarray)
+    assert answers.shape == (2, 2, 5)
+
+
 def test_type_int():
     model = HuggingFaceCompletion(TEST_MODEL, max_tokens=10)
     answer = model("test", type="int")
     int(answer)
+
+    answers = model(["test", "other_test"], type="int")
+    for answer in answers:
+        int(answer)
 
 
 def test_type_float():
     model = HuggingFaceCompletion(TEST_MODEL, max_tokens=10)
     answer = model("test", type="float")
     float(answer)
+
+    answers = model(["test", "other_test"], type="float")
+    for answer in answers:
+        float(answer)
 
 
 def test_incompatible_constraints():
@@ -46,6 +66,10 @@ def test_choices():
     answer = model("test", is_in=choices)
     assert answer in choices
 
+    answers = model(["test", "other_test"], is_in=choices)
+    for answer in answers:
+        assert answer in choices
+
 
 def test_stop():
     model = HuggingFaceCompletion(TEST_MODEL, max_tokens=1000)
@@ -54,6 +78,11 @@ def test_stop():
     answer = model("test", stop_at=stop)
     for seq in stop:
         assert seq not in answer
+
+    answers = model(["test", "other_test"], stop_at=stop)
+    for seq in stop:
+        for answer in answers:
+            assert seq not in answer
 
 
 @pytest.mark.xfail


### PR DESCRIPTION
The vectorization of `transformers` models is currently broken, mostly because when we batch prompts and add for several samples at the same time the model returns a flat array that we need to reshape. I added new tests.