### PR TITLE
Add `JSON` generation method

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -14,10 +14,10 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Build the documentation with Sphinx
         run: |

--- a/.github/workflows/publish_documentation.yml
+++ b/.github/workflows/publish_documentation.yml
@@ -15,10 +15,10 @@ jobs:
       - name: Checkout the branch
         uses: actions/checkout@v2.3.1
 
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: "3.10"
 
       - name: Build the documentation with Sphinx
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Build sdist and wheel
       run: |
         python -m pip install -U pip

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,7 +14,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - uses: pre-commit/action@v3.0.0
 
   tests:
@@ -24,7 +24,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:
-        python-version: 3.9
+        python-version: "3.10"
     - name: Set up test environment
       run: |
         python -m pip install --upgrade pip

--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ channels:
   - conda-forge
   - huggingface
 dependencies:
-  - python<3.11.0
+  - python==3.10.0
   - jinja2
   - numpy
   - pillow

--- a/outlines/text/generate/__init__.py
+++ b/outlines/text/generate/__init__.py
@@ -1,2 +1,2 @@
 from .continuation import continuation
-from .regex import choice, float, integer, regex
+from .regex import choice, float, integer, json, regex

--- a/outlines/text/generate/regex.py
+++ b/outlines/text/generate/regex.py
@@ -1,11 +1,14 @@
 import collections
 import math
-from typing import List, Optional, Tuple
+from json import dumps
+from typing import List, Optional, Tuple, Union
 
 import interegular
 import torch
+from pydantic import BaseModel
 
 from outlines.text.generate.continuation import Continuation
+from outlines.text.json_schema import build_regex_from_schema
 from outlines.text.parsing import find_partial_matches, map_partial_states_to_vocab
 
 
@@ -203,4 +206,25 @@ def float(model, max_tokens: Optional[int] = None):
 def choice(model, choices: List[str], max_tokens: Optional[int] = None):
     """Choose between different sequences."""
     regex_str = r"(" + r"|".join(choices) + r")"
+    return Regex(model, regex_str, max_tokens)
+
+
+def json(model, schema: Union[str, BaseModel], max_tokens: Optional[int] = None):
+    """Generate a text sequence that follows a JSON schema.
+
+    Parameters
+    ---------
+    model
+        The model to use to computes the next-token logits.
+    schema
+        The JSON schema, or Pydantic model, that guides the generation.
+    max_tokens
+        The maximum number of tokens to generate at each step.
+
+    """
+    if isinstance(schema, type(BaseModel)):
+        schema = dumps(schema.model_json_schema())
+
+    regex_str = build_regex_from_schema(schema)
+
     return Regex(model, regex_str, max_tokens)

--- a/outlines/text/generate/sequence.py
+++ b/outlines/text/generate/sequence.py
@@ -233,7 +233,7 @@ class Sequence:
                 updated_token_ids[:, num_prompt_tokens:]
             ).flatten()
 
-        result = self.model.tokenizer.decode(token_ids)
+        result = self.model.tokenizer.decode(token_ids[..., num_prompt_tokens:])
         result = self.postprocess_completions(result)
 
         if len(result) == 1:

--- a/outlines/text/json_schema.py
+++ b/outlines/text/json_schema.py
@@ -1,0 +1,239 @@
+import itertools
+import json
+from typing import Dict
+
+STRING = r'".*"'
+INTEGER = r"(0|[1-9][0-9]*)"
+NUMBER = rf"(-)?({INTEGER})(\.[0-9]+)?([eE][+-][0-9]+)?"
+BOOLEAN = r"(true|false)"
+NULL = r"null"
+
+type_to_regex = {
+    "string": STRING,
+    "integer": INTEGER,
+    "number": NUMBER,
+    "boolean": BOOLEAN,
+    "null": NULL,
+}
+
+
+def build_regex_from_schema(schema: str):
+    """Turn a JSON schema into a regex that matches any JSON object that follows
+    this schema.
+
+    Parameters
+    ----------
+    schema
+        A string that contains the JSON schema.
+
+    Returns
+    -------
+    A string that contains a regular expression that matches any JSON object that
+    follows the schema.
+
+    """
+    schedule = build_schedule_from_schema(schema)
+
+    regex = ""
+    for step in schedule:
+        regex += match_step_to_regex(step)
+
+    return regex
+
+
+def build_schedule_from_schema(schema: str):
+    """Turn a JSON schema into a regex that matches any JSON object that follows
+    this schema.
+
+    JSON Schema is a declarative language that allows to annotate JSON documents
+    with types and descriptions. These schemas can be generated from any Python
+    datastructure that has type annotation: namedtuples, dataclasses, Pydantic
+    models. And by ensuring that the generation respects the schema we ensure
+    that the output can be parsed into these objects.
+    This function parses the provided schema and builds a generation schedule which
+    mixes deterministic generation (fixed strings), and sampling with constraints.
+
+    Parameters
+    ----------
+    schema
+        A string that represents a JSON Schema.
+
+    Returns
+    -------
+    A generation schedule. A list of strings that represent the JSON
+    schema's structure and regular expression that define the structure of
+    the fields.
+
+    References
+    ----------
+    .. [0] JSON Schema. https://json-schema.org/
+
+    """
+    schema = json.loads(schema)
+
+    # Find object definitions in the schema, if any
+    definitions = {}
+    if "$defs" in schema:
+        for definition, annotation in schema["$defs"].items():
+            definitions[f"#/$defs/{definition}"] = annotation
+
+    schema = expand_json_schema(schema, definitions)
+    schedule = build_schedule_from_instance(schema)
+
+    # Concatenate adjacent strings
+    reduced_schedule = [
+        x
+        for cls, grp in itertools.groupby(schedule, type)
+        for x in (("".join(grp),) if cls is str else grp)
+    ]
+
+    return reduced_schedule
+
+
+def expand_json_schema(raw_schema: Dict, definitions: Dict):
+    """Replace references by their value in the JSON Schema.
+
+    This recursively follows the references to other schemas in case
+    of nested models. Other schemas are stored under the "definitions"
+    key in the schema of the top-level model.
+
+    Parameters
+    ---------
+    raw_schema
+        The raw JSON schema as a Python dictionary, possibly with definitions
+        and references.
+    definitions
+        The currently known definitions.
+
+    Returns
+    -------
+    A dictionary that represents the flattened equivalent of the input
+    JSON schema.
+
+    """
+    expanded_properties = {}
+
+    if "properties" in raw_schema:
+        for name, value in raw_schema["properties"].items():
+            if "$ref" in value:  # if item is a single element
+                expanded_properties[name] = expand_json_schema(
+                    definitions[value["$ref"]], definitions
+                )
+            elif "type" in value and value["type"] == "array":  # if item is a list
+                expanded_properties[name] = value
+                if "$ref" in value["items"]:
+                    expanded_properties[name]["items"] = expand_json_schema(
+                        definitions[value["items"]["$ref"]], definitions
+                    )
+                else:
+                    expanded_properties[name]["items"] = value["items"]
+            else:
+                expanded_properties[name] = value
+
+        return {
+            "title": raw_schema["title"],
+            "type": raw_schema["type"],
+            "properties": expanded_properties,
+        }
+
+    else:
+        return raw_schema
+
+
+def build_schedule_from_instance(instance: Dict, indent: int = 0):
+    """Build a generation schedule from a instance.
+
+    This recursively follows the references to other instances.
+
+    Parameters
+    ----------
+    instance
+        An instance, can be the JSON schema itself.
+    indent
+        The current indentation level
+
+    Returns
+    -------
+    A generation schedule for the instance, a list of strings that represent
+    the structure of the JSON schema and dictionaries that contain the
+    instance definition.
+
+    """
+    schedule = []
+    if "properties" in instance:
+        schedule.append("{\n")
+        schedule += build_schedule_from_instance(instance["properties"], indent + 2)
+        if indent > 0:
+            schedule.append(" " * indent)
+        schedule.append("}")
+    else:
+        for i, (name, annotation) in enumerate(instance.items()):
+            schedule.append(" " * indent)
+            schedule.append(f'"{name}": ')
+            if "anyOf" in annotation:
+                schedule.append(annotation)
+            elif annotation["type"] == "object":
+                schedule += build_schedule_from_instance(annotation, indent)
+            else:
+                schedule.append(annotation)
+
+            # We cannot add commas after the last key-value pair in JSON
+            if i == len(instance) - 1:
+                schedule.append("\n")
+            else:
+                schedule.append(",\n")
+
+    return schedule
+
+
+def match_step_to_regex(step):
+    """Translate an element of a JSON schema to a regex that defines its content.
+
+    Parameters
+    ----------
+    step:
+        A string that represents the schema's structure, or a dictionnary
+        that represents a field in the schema.
+
+    Returns
+    -------
+    A string that represents a regular expression that defines the value of the
+    schedule's step.
+
+    """
+    match step:
+        case str() as step:
+            return step
+
+        case {"enum": choices, "type": "string"}:
+            choices = [f'"{choice}"' for choice in choices]
+            return f"({'|'.join(choices)})"
+        case {"enum": choices}:
+            choices = [str(choice) for choice in choices]
+            return f"({'|'.join(choices)})"
+
+        case {"type": "array", "items": items}:
+            item_regexes = match_step_to_regex(items)
+            return rf"\[({item_regexes})(,({item_regexes}))*\]"
+
+        case {"type": "object"} as object:
+            steps = build_schedule_from_schema(json.dumps(object))
+            regex_str = ""
+            for step in steps:
+                regex_str += match_step_to_regex(step)
+            return regex_str
+
+        case {"type": "string", "maxLength": max_length}:
+            return f'".{{,{max_length}}}"'
+        case {"type": "string", "minLength": min_length}:
+            return f'".{{{min_length},}}"'
+
+        case {"type": field_type}:
+            return type_to_regex[field_type]
+
+        case {"anyOf": choices}:
+            regexes = [match_step_to_regex(choice) for choice in choices]
+            return rf"({'|'.join(regexes)})"
+
+        case _:
+            raise NotImplementedError

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,7 @@ dynamic = ["version"]
 test = [
     "diffusers",
     "pre-commit",
+    "pydantic>=2.0",
     "pytest",
     "pytest-cov",
     "transformers",

--- a/tests/text/generate/test_integration_transfomers.py
+++ b/tests/text/generate/test_integration_transfomers.py
@@ -53,7 +53,7 @@ def test_transformers_various_regexes():
     prompt = "Write an email address"
     regex_str = r"([a-z]{10})@([a-z]{5})\.([a-z]{3})"
     sequence = generate.regex(model, regex_str)(prompt, rng=rng)
-    assert re.fullmatch(regex_str, sequence[len(prompt) :]) is not None
+    assert re.fullmatch(regex_str, sequence) is not None
 
 
 def test_transformers_integration_integer():
@@ -65,9 +65,8 @@ def test_transformers_integration_integer():
     prompt = "Write a short sentence"
     sequence = generate.integer(model, max_tokens=10)(prompt, rng=rng)
 
-    generated = sequence[len(prompt) :]
-    assert generated[0] != 0
-    int(generated)
+    assert sequence[0] != 0
+    int(sequence)
 
 
 def test_transformers_integration_integer_array():
@@ -80,8 +79,8 @@ def test_transformers_integration_integer_array():
     sequence = generate.integer(model, max_tokens=10)(prompts, rng=rng)
     assert isinstance(sequence, list)
     assert len(sequence) == 2
-    int(sequence[0][len(prompts[0]) :])
-    int(sequence[1][len(prompts[1]) :])
+    int(sequence[0])
+    int(sequence[1])
 
 
 def test_transformers_integration_float():
@@ -93,9 +92,8 @@ def test_transformers_integration_float():
     prompt = "Write a short sentence"
     sequence = generate.float(model, max_tokens=10)(prompt, rng=rng)
 
-    generated = sequence[len(prompt) :]
-    assert generated[0] != 0
-    float(generated)
+    assert sequence[0] != 0
+    float(sequence)
 
 
 def test_transformers_integration_choice():
@@ -107,8 +105,7 @@ def test_transformers_integration_choice():
     prompt = "Write a short sentence "
     sequence = generate.choice(model, ["test", "choice"])(prompt, rng=rng)
 
-    generated = sequence[len(prompt) :]
-    assert generated == "test" or generated == "choice"
+    assert sequence == "test" or sequence == "choice"
 
 
 def test_transformers_integration_with_pad_token():

--- a/tests/text/generate/test_sequence.py
+++ b/tests/text/generate/test_sequence.py
@@ -285,7 +285,7 @@ def test_call_single_prompt():
     sequence = FinishAfterTwo(model)
 
     result = sequence("Test")
-    assert torch.equal(result, torch.tensor([0, 0, 1]))
+    assert torch.equal(result, torch.tensor([0, 1]))
 
 
 def test_call_prompt_list():
@@ -339,9 +339,7 @@ def test_call_prompt_list():
     sequence = FinishAfterThree(model)
 
     result = sequence(["Test1", "Test2", "Test3"])
-    assert torch.equal(
-        result, torch.tensor([[0, 2, 3, -1], [1, 2, 3, 4], [5, 2, 3, -1]])
-    )
+    assert torch.equal(result, torch.tensor([[2, 3, -1], [2, 3, 4], [2, 3, -1]]))
 
 
 def test_call_single_prompt_samples():
@@ -370,7 +368,7 @@ def test_call_single_prompt_samples():
     )
     sequence = FinishAfterTwo(model)
     result = sequence("Test", samples=3)
-    assert torch.equal(result, torch.tensor([[4, 0, 1], [4, 0, 1], [4, 0, 1]]))
+    assert torch.equal(result, torch.tensor([[0, 1], [0, 1], [0, 1]]))
 
     class FinishAfterOne(Sequence):
         def __init__(self, model):
@@ -392,7 +390,7 @@ def test_call_single_prompt_samples():
     )
     sequence = FinishAfterOne(model)
     result = sequence("Test", samples=3)
-    assert torch.equal(result, torch.tensor([[4, 0], [4, 0], [4, 0]]))
+    assert torch.equal(result, torch.tensor([[0], [0], [0]]))
 
 
 def test_call_prompt_list_samples():
@@ -433,7 +431,5 @@ def test_call_prompt_list_samples():
     result = sequence(["Test1", "Test2", "Test3"], samples=3)
     assert torch.equal(
         result,
-        torch.tile(
-            torch.tensor([[3, 0, 1, -1], [4, 0, 1, 2], [5, 0, 1, -1]]), (3, 1, 1)
-        ),
+        torch.tile(torch.tensor([[0, 1, -1], [0, 1, 2], [0, 1, -1]]), (3, 1, 1)),
     )

--- a/tests/text/test_json_schema.py
+++ b/tests/text/test_json_schema.py
@@ -1,0 +1,356 @@
+import json
+import re
+from enum import Enum
+from typing import List, Optional, Union
+
+import pytest
+from pydantic import BaseModel, constr
+
+from outlines.text.json_schema import (
+    BOOLEAN,
+    INTEGER,
+    NULL,
+    NUMBER,
+    STRING,
+    build_schedule_from_schema,
+    match_step_to_regex,
+)
+
+
+def test_pydantic_basic():
+    class User(BaseModel):
+        user_id: int
+        name: str
+        maxlength_name: constr(max_length=10)
+        minlength_name: constr(min_length=10)
+        value: float
+        is_true: bool
+
+    schema = json.dumps(User.model_json_schema())
+    schedule = build_schedule_from_schema(schema)
+    assert schedule == [
+        '{\n  "user_id": ',
+        {"title": "User Id", "type": "integer"},
+        ',\n  "name": ',
+        {"title": "Name", "type": "string"},
+        ',\n  "maxlength_name": ',
+        {"title": "Maxlength Name", "type": "string", "maxLength": 10},
+        ',\n  "minlength_name": ',
+        {"title": "Minlength Name", "type": "string", "minLength": 10},
+        ',\n  "value": ',
+        {"title": "Value", "type": "number"},
+        ',\n  "is_true": ',
+        {"title": "Is True", "type": "boolean"},
+        "\n}",
+    ]
+
+
+def test_pydantic_optional():
+    class Foo(BaseModel):
+        bar: Optional[str]
+
+    schema = json.dumps(Foo.model_json_schema())
+    schedule = build_schedule_from_schema(schema)
+    assert schedule == [
+        '{\n  "bar": ',
+        {"anyOf": [{"type": "string"}, {"type": "null"}], "title": "Bar"},
+        "\n}",
+    ]
+
+
+def test_pydantic_array():
+    class User(BaseModel):
+        user_id: int
+        value: List[float]
+
+    schema = json.dumps(User.model_json_schema())
+    schedule = build_schedule_from_schema(schema)
+    assert schedule == [
+        '{\n  "user_id": ',
+        {"title": "User Id", "type": "integer"},
+        ',\n  "value": ',
+        {"title": "Value", "type": "array", "items": {"type": "number"}},
+        "\n}",
+    ]
+
+
+def test_pydantic_enum():
+    class Name(str, Enum):
+        john = "John"
+        marc = "Marc"
+        michel = "Michel"
+
+    class User(BaseModel):
+        user_id: int
+        name: Name
+
+    schema = json.dumps(User.model_json_schema())
+    schedule = build_schedule_from_schema(schema)
+    assert schedule == [
+        '{\n  "user_id": ',
+        {"title": "User Id", "type": "integer"},
+        ',\n  "name": ',
+        {
+            "title": "Name",
+            "enum": ["John", "Marc", "Michel"],
+            "type": "string",
+        },
+        "\n}",
+    ]
+
+
+def test_pydantic_nested():
+    """Arbitrarily nested schema."""
+
+    class Fizz(BaseModel):
+        buzz: str
+
+    class Foo(BaseModel):
+        count: int
+        size: Fizz
+
+    class Bar(BaseModel):
+        apple: str
+        banana: str
+
+    class Spam(BaseModel):
+        foo: Foo
+        bars: Bar
+
+    # We need to a recursive function to parse nested schemas
+    schema = json.dumps(Spam.model_json_schema())
+    schedule = build_schedule_from_schema(schema)
+    assert schedule == [
+        '{\n  "foo": {\n    "count": ',
+        {"title": "Count", "type": "integer"},
+        ',\n    "size": {\n      "buzz": ',
+        {"title": "Buzz", "type": "string"},
+        '\n    }\n  },\n  "bars": {\n    "apple": ',
+        {"title": "Apple", "type": "string"},
+        ',\n    "banana": ',
+        {"title": "Banana", "type": "string"},
+        "\n  }\n}",
+    ]
+
+
+def test_pydantic_list_object():
+    class Foo(BaseModel):
+        count: int
+
+    class Spam(BaseModel):
+        foo: List[Foo]
+
+    # We need to a recursive function to parse nested schemas
+    schema = json.dumps(Spam.model_json_schema())
+    schedule = build_schedule_from_schema(schema)
+    assert schedule == [
+        '{\n  "foo": ',
+        {
+            "items": {
+                "title": "Foo",
+                "type": "object",
+                "properties": {"count": {"title": "Count", "type": "integer"}},
+            },
+            "title": "Foo",
+            "type": "array",
+        },
+        "\n}",
+    ]
+
+
+def test_pydantic_union():
+    """Schemas with Union types."""
+
+    class Spam(BaseModel):
+        foo: int
+        bar: Union[float, str]
+
+    schema = json.dumps(Spam.model_json_schema())
+    schedule = build_schedule_from_schema(schema)
+    assert schedule == [
+        '{\n  "foo": ',
+        {"title": "Foo", "type": "integer"},
+        ',\n  "bar": ',
+        {"title": "Bar", "anyOf": [{"type": "number"}, {"type": "string"}]},
+        "\n}",
+    ]
+
+
+def test_json_schema():
+    schema = '{"title": "User", "type": "object", "properties": {"user_id": {"title": "User Id", "type": "integer"}, "name": {"title": "Name", "type": "string"}}, "required": ["user_id", "name"]}'
+    schedule = build_schedule_from_schema(schema)
+    assert schedule == [
+        '{\n  "user_id": ',
+        {"title": "User Id", "type": "integer"},
+        ',\n  "name": ',
+        {"title": "Name", "type": "string"},
+        "\n}",
+    ]
+
+
+class MockTokenizer:
+    pad_token_id = 0
+    eos_token_id = 0
+
+
+class MockModel:
+    tokenizer = MockTokenizer()
+    device = "cpu"
+
+
+@pytest.mark.parametrize(
+    "pattern,does_match",
+    [
+        ("0", True),
+        ("1", True),
+        ("-1", False),
+        ("01", False),
+        ("1.3", False),
+        ("t", False),
+    ],
+)
+def test_match_integer(pattern, does_match):
+    step = {"title": "Foo", "type": "integer"}
+    regex = match_step_to_regex(step)
+    assert regex == INTEGER
+
+    match = re.fullmatch(regex, pattern)
+    if does_match:
+        assert match[0] == pattern
+        assert match.span() == (0, len(pattern))
+    else:
+        assert match is None
+
+
+@pytest.mark.parametrize(
+    "pattern,does_match",
+    [
+        ("1", True),
+        ("0", True),
+        ("01", False),
+        (".3", False),
+        ("1.3", True),
+        ("-1.3", True),
+        ("1.3e9", False),
+        ("1.3e+9", True),
+    ],
+)
+def test_match_number(pattern, does_match):
+    step = {"title": "Foo", "type": "number"}
+    regex = match_step_to_regex(step)
+    assert regex == NUMBER
+
+    match = re.fullmatch(regex, pattern)
+    if does_match:
+        assert match[0] == pattern
+        assert match.span() == (0, len(pattern))
+    else:
+        assert match is None
+
+
+@pytest.mark.parametrize(
+    "step,regex,examples",
+    [
+        (
+            {"title": "Foo", "type": "string"},
+            STRING,
+            [("unquotedstring", False), ('"quoted_string"', True)],
+        ),
+        (
+            {"title": "Foo", "type": "string", "maxLength": 3},
+            '".{,3}"',
+            [('"ab"', True), ('"abcd"', False)],
+        ),
+        (
+            {"title": "Foo", "type": "string", "minLength": 3},
+            '".{3,}"',
+            [('"ab"', False), ('"abcd"', True)],
+        ),
+        (
+            {"title": "Foo", "type": "boolean"},
+            BOOLEAN,
+            [
+                ("true", True),
+                ("false", True),
+                ("null", False),
+                ("0", False),
+            ],
+        ),
+        (
+            {"title": "Foo", "type": "null"},
+            NULL,
+            [
+                ("null", True),
+                ("true", False),
+                ("0", False),
+            ],
+        ),
+        (
+            {"title": "Foo", "anyOf": [{"type": "string"}, {"type": "number"}]},
+            f"({STRING}|{NUMBER})",
+            [
+                ('"string"', True),
+                ("1000", True),
+                ("true", False),
+            ],
+        ),
+        (
+            {"title": "Foo", "enum": ["Marc", "Jean"], "type": "string"},
+            '("Marc"|"Jean")',
+            [('"Marc"', True), ('"Jean"', True), ('"John"', False)],
+        ),
+        (
+            {"title": "Foo", "enum": [0, 1], "type": "integer"},
+            "(0|1)",
+            [("0", True), ("1", True), ("a", False)],
+        ),
+        (
+            {
+                "title": "Foo",
+                "type": "object",
+                "properties": {"count": {"title": "Count", "type": "integer"}},
+            },
+            '{\n  "count": ' + INTEGER + "\n}",
+            [('{\n  "count": 100\n}', True)],
+        ),
+        (
+            {"title": "Foo", "type": "array", "items": {"type": "number"}},
+            rf"\[({NUMBER})(,({NUMBER}))*\]",
+            [("[1e+9,1.3]", True)],
+        ),
+        (
+            {
+                "title": "Foo",
+                "type": "array",
+                "items": {"anyOf": [{"type": "boolean"}, {"type": "null"}]},
+            },
+            r"\[(((true|false)|null))(,(((true|false)|null)))*\]",
+            [("[true,null,false]", True)],
+        ),
+        (
+            {
+                "title": "Bar",
+                "type": "object",
+                "properties": {
+                    "fuzz": {
+                        "title": "Foo",
+                        "type": "object",
+                        "properties": {"spam": {"title": "Spam", "type": "integer"}},
+                    }
+                },
+            },
+            '{\n  "fuzz": {\n    "spam": ' + INTEGER + "\n  }\n}",
+            [('{\n  "fuzz": {\n    "spam": 100\n  }\n}', True)],
+        ),
+    ],
+)
+def test_match(step, regex, examples):
+    assert match_step_to_regex(step) == regex
+
+    for string, does_match in examples:
+        match = re.fullmatch(regex, string)
+        if does_match:
+            assert match[0] == string
+            assert match.span() == (0, len(string))
+        else:
+            assert match is None


### PR DESCRIPTION
In this PR we add a new generation method that can generate valid JSON following a [Pydantic mode](https://docs.pydantic.dev/latest/#pydantic-examples) or [JSON Schema](https://json-schema.org/) specification.

We first parse the (possibly nested) JSON schema into a generation schedule, which is a list of strings that represent the JSON structure, and annotations that correspond to the field specifications. The following annotations are currently supported, with a minimal set of functionalities:

- `string`
- `int`
- `float`
- `bool`
- `Union[type1, type2]`
- `enum`
- `List[type]`
- `List[Union[type1, type2]]`
- `Optional[type]`
- Nested schema
- `maxLength` for strings
- `minLength` for strings 

The tests demonstrate how to build a schedule from Pydantic models, using the models' `schema_json` method. 

We also add an `outlines.text.generate.json` function that parses a JSON schema, turns it into a regex and instantiates the `Regex` class.