### PR TITLE
Add `Integer` sequence generator

### DIFF
--- a/outlines/models/tokenizer.py
+++ b/outlines/models/tokenizer.py
@@ -1,5 +1,5 @@
 from abc import abstractmethod
-from typing import List, Protocol, Tuple, Union
+from typing import Dict, List, Protocol, Tuple, Union
 
 import numpy as np
 from numpy.typing import NDArray
@@ -9,6 +9,7 @@ class Tokenizer(Protocol):
     eos_token: str
     eos_token_id: int
     pad_token_id: int
+    vocabulary: Dict[str, int]
 
     @abstractmethod
     def encode(

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -34,6 +34,7 @@ class Transformers:
         batch_shape = input_ids.shape[:-1]
         num_tokens = input_ids.shape[-1]
         input_ids = input_ids.reshape(math.prod(batch_shape), num_tokens)
+
         output = self.model(
             input_ids,
             attention_mask=attention_mask,
@@ -42,12 +43,10 @@ class Transformers:
             output_hidden_states=False,
         )
         next_token_logits = output.logits[:, -1, :]
-        probs = torch.nn.functional.softmax(next_token_logits, dim=-1).squeeze()
 
-        probs = torch.atleast_2d(probs)
-        probs = probs.reshape(batch_shape + (-1,))
+        next_token_logits = next_token_logits.reshape(batch_shape + (-1,))
 
-        return probs
+        return next_token_logits
 
 
 class TransformersTokenizer(Tokenizer):
@@ -67,6 +66,8 @@ class TransformersTokenizer(Tokenizer):
         else:
             self.pad_token_id = self.tokenizer.pad_token_id
             self.pad_token = self.tokenizer.pad_token
+
+        self.vocabulary = self.tokenizer.get_vocab()
 
     def encode(
         self, prompt: Union[str, List[str]], **kwargs

--- a/outlines/text/generate/__init__.py
+++ b/outlines/text/generate/__init__.py
@@ -1,1 +1,2 @@
 from .continuation import continuation
+from .integer import integer

--- a/outlines/text/generate/continuation.py
+++ b/outlines/text/generate/continuation.py
@@ -8,11 +8,12 @@ from outlines.text.generate.sequence import Sequence
 class Continuation(Sequence):
     """Represents a completion generation model.
 
-    `Completion` instances are unconstrained generation models that stop when an EOS token
-    has been found or when the maximum number of tokens has been reached.
+    `Continuation` instances are unconstrained generation models that stop when
+    an EOS token has been found or when the maximum number of tokens has been
+    reached.
 
-    >> import outlines.text as text
-    >> sequence = text.sequence(model)("Say something")
+    >>> import outlines.text as text
+    >>> sequence = text.generate.continuation(model)("Say something")
 
     """
 

--- a/outlines/text/generate/integer.py
+++ b/outlines/text/generate/integer.py
@@ -1,0 +1,96 @@
+import math
+from typing import List, Optional, Tuple
+
+import interegular
+import torch
+
+from outlines.text.generate.continuation import Continuation
+from outlines.text.parsing import find_partial_matches, map_partial_states_to_vocab
+
+
+class Integer(Continuation):
+    """Represents a integer generation model.
+
+    `Integer` instances are constrained generation models that only
+    generate integer values. Leading zeros are fobidden. EOS tokens
+    are only allowed after at least one digit has been generated.
+
+    >>> import outlines.text as text
+    >>> sequence = text.generate.integer(model)("Return an integer between 0 and 10")
+
+    """
+
+    def __init__(self, model, max_tokens: Optional[int]):
+        super().__init__(model, max_tokens)
+
+        vocabulary = model.tokenizer.vocabulary
+        sorted_vocabulary = [
+            k for k, v in sorted(vocabulary.items(), key=lambda kv: kv[1])
+        ]
+
+        int_regex_string = r"(0|[1-9][0-9]+)"
+        int_regex_pattern = interegular.parse_pattern(int_regex_string)
+        self.int_regex_fsm = int_regex_pattern.simplify().to_fsm()
+
+        def partial_match_filter(string, end_idx, state_seq):
+            if end_idx is not None and end_idx < len(string) - 1:
+                return False
+            return True
+
+        pstate_to_vocab = map_partial_states_to_vocab(
+            list(sorted_vocabulary),
+            {"INT": self.int_regex_fsm},
+            True,
+            partial_match_filter,
+        )
+        self.pstate_to_vocab = {k: list(v) for k, v in pstate_to_vocab.items()}
+
+    def create_proposal(
+        self, generated_token_ids: torch.LongTensor, logits: torch.DoubleTensor
+    ) -> torch.DoubleTensor:
+        """Modify the next-token logits so that only integers can be generated.
+
+        Parameters
+        ----------
+        generated_token_ids
+            The token ids generated so far.
+        logits
+            The next-token logits.
+
+        """
+        if generated_token_ids.shape[-1] > 0:
+            # TODO Make this work for `generated_token_ids` of arbitrary shape
+            sampled_sequences = self.model.tokenizer.decode(generated_token_ids)
+            if isinstance(sampled_sequences, str):
+                sampled_sequences = [sampled_sequences]
+            partial_matches = [
+                find_partial_matches(self.int_regex_fsm, sequence)
+                for sequence in sampled_sequences
+            ]
+            pmatches = [
+                max(partial_match, key=lambda x: x[0] if x[0] is not None else -1)
+                for partial_match in partial_matches
+            ]
+            self.pstates: List[Tuple[str, int]] = [
+                (self.pstates[0][0], pmatch[1][-1]) for pmatch in pmatches
+            ]
+        else:
+            self.pstates = [
+                ("INT", self.int_regex_fsm.initial)
+                for _ in range(generated_token_ids.shape[0])
+            ]
+
+        masks = []
+        for pstate in self.pstates:
+            next_support = self.pstate_to_vocab[pstate]
+            mask = torch.full((len(self.model.tokenizer.vocabulary),), -math.inf)
+            mask[next_support] = 0
+            masks.append(mask.unsqueeze(0))
+
+        mask = torch.concatenate(masks, dim=0)
+
+        return logits + mask
+
+
+def integer(model, max_tokens: Optional[int] = None):
+    return Integer(model, max_tokens)

--- a/tests/text/generate/test_integer.py
+++ b/tests/text/generate/test_integer.py
@@ -1,0 +1,70 @@
+import math
+
+import torch
+
+from outlines.text.generate.integer import integer
+
+
+class Tokenizer:
+    eos_token = "<EOS>"
+    eos_token_id = 0
+    pad_token_id = -1
+    vocabulary = {"<EOS>": 0, "00": 1, "1": 2, "0.": 3, "431": 4, "a": 5}
+    tokens = list(vocabulary.keys())
+
+    def decode(self, token_ids):
+        decoded = []
+        for i in range(token_ids.shape[0]):
+            decoded.append("".join([self.tokens[idx] for idx in token_ids[i]]))
+
+        return decoded
+
+
+class Model:
+    tokenizer = Tokenizer()
+    device = "cpu"
+
+
+def test_integer_proposal():
+    model = Model()
+    generator = integer(model)
+
+    logits = torch.ones(len(model.tokenizer.vocabulary))
+    result = generator.create_proposal(torch.tensor([[]]), logits)
+    assert torch.equal(
+        result, torch.tensor([[-math.inf, -math.inf, 1.0, -math.inf, 1.0, -math.inf]])
+    )
+
+    logits = torch.ones(len(model.tokenizer.vocabulary))
+    result = generator.create_proposal(torch.tensor([[2]]), logits)
+    assert torch.equal(
+        result, torch.tensor([[-math.inf, 1.0, 1.0, -math.inf, 1.0, -math.inf]])
+    )
+
+    logits = torch.ones(len(model.tokenizer.vocabulary))
+    result = generator.create_proposal(torch.tensor([[4]]), logits)
+    assert torch.equal(
+        result, torch.tensor([[-math.inf, 1.0, 1.0, -math.inf, 1.0, -math.inf]])
+    )
+
+    logits = torch.ones(len(model.tokenizer.vocabulary))
+    result = generator.create_proposal(torch.tensor([[4], [2]]), logits)
+    assert torch.equal(
+        result,
+        torch.tensor(
+            [
+                [-math.inf, 1.0, 1.0, -math.inf, 1.0, -math.inf],
+                [-math.inf, 1.0, 1.0, -math.inf, 1.0, -math.inf],
+            ]
+        ),
+    )
+
+    logits = torch.ones((4, len(model.tokenizer.vocabulary)))
+    result = generator.create_proposal(torch.tensor([[]]), logits)
+    assert torch.equal(
+        result,
+        torch.tile(
+            torch.tensor([[-math.inf, -math.inf, 1.0, -math.inf, 1.0, -math.inf]]),
+            (4, 1),
+        ),
+    )

--- a/tests/text/generate/test_integration_transfomers.py
+++ b/tests/text/generate/test_integration_transfomers.py
@@ -1,7 +1,9 @@
+import pytest
 import torch
 
 import outlines.models as models
 from outlines.text.generate.continuation import continuation
+from outlines.text.generate.integer import integer
 
 
 def test_transformers_integration_continuation():
@@ -16,6 +18,51 @@ def test_transformers_integration_continuation():
 
     sequence = continuation(model, max_tokens=10)("Write a short sentence", rng=rng)
     assert isinstance(sequence, str)
+
+    prompts = ["Write a short sentence", "And another one"]
+    sequence = continuation(model, max_tokens=10)(prompts, rng=rng)
+    assert isinstance(sequence, list)
+    assert len(sequence) == 2
+    assert isinstance(sequence[0], str)
+
+
+@pytest.mark.xfail
+def test_transformers_integration_continuation_array_samples():
+    rng = torch.Generator()
+    rng.manual_seed(0)
+
+    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
+    model = models.transformers(model_name, device="cpu")
+    prompts = ["Write a short sentence", "And another one"]
+    _ = continuation(model, max_tokens=10)(prompts, rng=rng, samples=3)
+
+
+def test_transformers_integration_integer():
+    rng = torch.Generator()
+    rng.manual_seed(0)
+
+    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
+    model = models.transformers(model_name, device="cpu")
+    prompt = "Write a short sentence"
+    sequence = integer(model, max_tokens=10)(prompt, rng=rng)
+
+    generated = sequence[len(prompt) :]
+    assert generated[0] != 0
+    int(generated)
+
+
+def test_transformers_integration_integer_array():
+    rng = torch.Generator()
+    rng.manual_seed(0)
+
+    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
+    model = models.transformers(model_name, device="cpu")
+    prompts = ["Give me a number", "And another one"]
+    sequence = integer(model, max_tokens=10)(prompts, rng=rng)
+    assert isinstance(sequence, list)
+    assert len(sequence) == 2
+    int(sequence[0][len(prompts[0]) :])
+    int(sequence[1][len(prompts[1]) :])
 
 
 def test_transformers_integration_with_pad_token():


### PR DESCRIPTION
In this PR I introduce a sequence generator that only outputs integers. Closes #153.

The generator can currently generate sequences that have leading zeros, which are then trimmed during post-processing. I am not sure what we should do about it. On one hand we can ignore it (maybe the LLM has seen this during training), on the other hand we could use the pre-processing approach described in #131.