### PR TITLE
Generalize parse state cloning

### DIFF
--- a/examples/parsing.py
+++ b/examples/parsing.py
@@ -1,6 +1,7 @@
 """An example illustrating parser-based masking."""
 import math
 import time
+import urllib.request
 
 import torch
 from lark import Lark
@@ -26,23 +27,33 @@ model = AutoModelForCausalLM.from_pretrained(
     checkpoint, trust_remote_code=True, revision=revision
 ).to(device)
 
-input_text = "def "
-inputs = tokenizer.encode(input_text, return_tensors="pt").to(device)
+sql_grammar_url = "https://github.com/zbrookle/sql_to_ibis/raw/0e9226da42065940ce21439d490f9fcacadc7f92/sql_to_ibis/grammar/sql.lark"
+sql_grammar = "".join(
+    [line.decode("utf-8") for line in urllib.request.urlopen(sql_grammar_url)]
+)
+with open("sql_grammar.lark", "w") as f:
+    f.write(sql_grammar)
+
+sqlparser = Lark.open(
+    "sql_grammar.lark",
+    parser="lalr",
+)
+
+pyparser = Lark.open_from_package(
+    "lark",
+    "python.lark",
+    ["grammars"],
+    parser="lalr",
+    postlex=PartialPythonIndenter(),
+    start="file_input",
+)
 
 
 class ParserLogitsProcessor(LogitsProcessor):
     """Bias invalid token scores according to a running parse state."""
 
-    def __init__(self):
-        pyparser = Lark.open_from_package(
-            "lark",
-            "python.lark",
-            ["grammars"],
-            parser="lalr",
-            postlex=PartialPythonIndenter(),
-            start="file_input",
-        )
-        ip = pyparser.parse_interactive("")
+    def __init__(self, parser):
+        ip = parser.parse_interactive("")
         self.parser_state = ip.parser_state
         self.states_stack = [self.parser_state]
         self.token_seq = None
@@ -64,10 +75,8 @@ class ParserLogitsProcessor(LogitsProcessor):
 
         self.parser_state, partial_tokens = parse_to_end(self.parser_state)
 
-        print("Parsed:\n")
-        print(self.token_seq)
-
-        print(partial_tokens)
+        print(f'parsed:"{self.token_seq}"')
+        print(f"partial_tokens: {partial_tokens}")
 
         mask = torch.full_like(scores, -math.inf)
 
@@ -90,18 +99,22 @@ class ParserLogitsProcessor(LogitsProcessor):
             except (UnexpectedToken, UnexpectedCharacters, DedentError):
                 pass
 
-        print(f"Next token masking duration: {time.perf_counter() - t0}")
+        print(f"next token masking duration: {time.perf_counter() - t0}")
 
         return scores + mask
 
 
 set_seed(20399)
 
+parser = sqlparser
+input_text = "select "
+inputs = tokenizer.encode(input_text, return_tensors="pt").to(device)
+
 outputs = model.generate(
     inputs,
     max_length=100,
     temperature=0.1,
-    logits_processor=LogitsProcessorList([ParserLogitsProcessor()]),
+    logits_processor=LogitsProcessorList([ParserLogitsProcessor(parser)]),
     renormalize_logits=True,
 )
 

--- a/outlines/text/parsing.py
+++ b/outlines/text/parsing.py
@@ -251,9 +251,14 @@ def copy_ip(ip: "InteractiveParser") -> "InteractiveParser":
 
 
 def parse_to_end(parser_state: ParserState) -> Tuple[ParserState, Set[str]]:
-    """Continue parsing from the current parse state and return partial next tokens."""
+    """Continue parsing from the current parse state and return partial next tokens.
 
-    parser_state = copy_parser_state(parser_state)
+    .. warning::
+        The parse state `parser_state` is updated in-place and must be patched
+        to work with this function.  Either patch it manually or use
+        `copy_parser_state` before calling this.
+
+    """
 
     expected_next_tokens: Set[str] = set()
     try:

--- a/outlines/text/parsing.py
+++ b/outlines/text/parsing.py
@@ -25,7 +25,7 @@ from lark.exceptions import (
     UnexpectedToken,
 )
 from lark.indenter import PythonIndenter
-from lark.lexer import BasicLexer, LexerState, Scanner
+from lark.lexer import BasicLexer, ContextualLexer, LexerState, Scanner
 from lark.parsers.lalr_analysis import Shift
 from lark.parsers.lalr_interactive_parser import InteractiveParser
 from lark.parsers.lalr_parser import ParseConf, ParserState
@@ -206,28 +206,33 @@ def copy_lexer_thread(lexer_thread: "LexerThread") -> "LexerThread":
     res = copy(lexer_thread)
     res.lexer = copy(res.lexer)
 
-    if (
-        res.lexer.postlexer
-        and isinstance(res.lexer.postlexer, PythonIndenter)
-        and not isinstance(res.lexer.postlexer, PartialPythonIndenter)
-    ):
-        # Patch these methods so that the post lexer keeps its state
-        # XXX: This won't really work in generality.
-        postlexer = PartialPythonIndenter()
-        postlexer.paren_level = res.lexer.postlexer.paren_level
-        postlexer.indent_level = res.lexer.postlexer.indent_level
-        res.lexer.postlexer = postlexer
+    if getattr(res.lexer, "postlexer", None):
+        if isinstance(res.lexer.postlexer, PythonIndenter) and not isinstance(
+            res.lexer.postlexer, PartialPythonIndenter
+        ):
+            # Patch these methods so that the post lexer keeps its state
+            # XXX: This won't really work in generality.
+            postlexer = PartialPythonIndenter()
+            postlexer.paren_level = res.lexer.postlexer.paren_level
+            postlexer.indent_level = res.lexer.postlexer.indent_level
+            res.lexer.postlexer = postlexer
+        else:
+            res.lexer.postlexer = copy(res.lexer.postlexer)
 
     # Patch/replace the lexer objects so that they support partial matches
-    lexer = res.lexer.lexer
-    if not isinstance(lexer.root_lexer, PartialBasicLexer):
-        lexer.root_lexer = PartialBasicLexer(lexer.root_lexer)
+    context_lexer = res.lexer
 
-        basic_lexers = res.lexer.lexer.lexers
+    if not isinstance(context_lexer, ContextualLexer):
+        # XXX: The layouts change with the grammars
+        context_lexer = context_lexer.lexer
+        assert isinstance(context_lexer, ContextualLexer)
+
+    if not isinstance(context_lexer.root_lexer, PartialBasicLexer):
+        context_lexer.root_lexer = PartialBasicLexer(context_lexer.root_lexer)
+
+        basic_lexers = context_lexer.lexers
         for idx, lexer in basic_lexers.items():
             basic_lexers[idx] = PartialBasicLexer(lexer)
-
-    res.lexer.postlexer = copy(res.lexer.postlexer)
 
     return res
 

--- a/tests/text/test_parsing.py
+++ b/tests/text/test_parsing.py
@@ -30,27 +30,32 @@ def test_parse_to_end():
     )
 
     ip = pyparser.parse_interactive("x")
-    parser_state, expected_next_tokens = parse_to_end(ip.parser_state)
+    parser_state = copy_parser_state(ip.parser_state)
+    parser_state, expected_next_tokens = parse_to_end(parser_state)
     assert not parser_state.value_stack
     assert expected_next_tokens == {"NAME"}
 
     ip = pyparser.parse_interactive("x = '")
-    parser_state, expected_next_tokens = parse_to_end(ip.parser_state)
+    parser_state = copy_parser_state(ip.parser_state)
+    parser_state, expected_next_tokens = parse_to_end(parser_state)
     assert parser_state.value_stack[-1].type == "EQUAL"
     assert expected_next_tokens == {"LONG_STRING", "STRING"}
 
     ip = pyparser.parse_interactive("x = 'hi")
-    parser_state, expected_next_tokens = parse_to_end(ip.parser_state)
+    parser_state = copy_parser_state(ip.parser_state)
+    parser_state, expected_next_tokens = parse_to_end(parser_state)
     assert parser_state.value_stack[-1].type == "EQUAL"
     assert expected_next_tokens == {"STRING"}
 
     ip = pyparser.parse_interactive("x = ('hi")
-    parser_state, expected_next_tokens = parse_to_end(ip.parser_state)
+    parser_state = copy_parser_state(ip.parser_state)
+    parser_state, expected_next_tokens = parse_to_end(parser_state)
     assert parser_state.value_stack[-1].type == "LPAR"
     assert expected_next_tokens == {"STRING"}
 
     ip = pyparser.parse_interactive("def")
-    parser_state, expected_next_tokens = parse_to_end(ip.parser_state)
+    parser_state = copy_parser_state(ip.parser_state)
+    parser_state, expected_next_tokens = parse_to_end(parser_state)
     assert not parser_state.value_stack
     assert expected_next_tokens == {"NAME", "DEF"}
 
@@ -97,7 +102,7 @@ def test_sequential_parse_example():
         start="file_input",
     )
     ip = pyparser.parse_interactive("")
-    parser_state = ip.parser_state
+    parser_state = copy_parser_state(ip.parser_state)
 
     token_seq = ""
     for i, token in enumerate(input_tokens):
@@ -243,6 +248,9 @@ NAME: /[^\W\d]\w*/
     (parser_state,) = create_pmatch_parser_states(
         lp, terminals_to_states, term_type, ptoken, first_pmatch
     )
+    # These copies also patch the lexers in the parse state, which is now
+    # needed for use with `parse_to_end`
+    parser_state = copy_parser_state(parser_state)
     new_parser_state, expected_next_tokens = parse_to_end(parser_state)
     assert expected_next_tokens == {"NAME"}
 
@@ -252,6 +260,7 @@ NAME: /[^\W\d]\w*/
     (parser_state,) = create_pmatch_parser_states(
         lp, terminals_to_states, term_type, ptoken, first_pmatch
     )
+    parser_state = copy_parser_state(parser_state)
     new_parser_state, expected_next_tokens = parse_to_end(parser_state)
     assert not expected_next_tokens
 
@@ -261,6 +270,7 @@ NAME: /[^\W\d]\w*/
     (parser_state,) = create_pmatch_parser_states(
         lp, terminals_to_states, term_type, ptoken, first_pmatch
     )
+    parser_state = copy_parser_state(parser_state)
     with pytest.raises(UnexpectedToken):
         parse_to_end(parser_state)
 


### PR DESCRIPTION
This PR makes some simple generalizations to our custom `lark` parse state cloning.  It also adds SQL-guided generation as an extension to the existing LLM example.

N.B. Don't expect the example model (i.e. [`codegen-350M-mono`](https://huggingface.co/Salesforce/codegen-350M-mono)) to actually produce meaningful/interesting SQL; it was trained primarily/exclusively on Python code.  Also, the example SQL grammar could have issues of its own.