### PR TITLE
Fix overview document and a type hint

### DIFF
--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -18,7 +18,7 @@ Here is a simple Outlines program that highlights some of its key features:
 
    hello_world = where_from("Hello world")
    foobar = where_from("Foo Bar")
-   answer = complete([hello_world, foobar], num_samples=3, stop_at=["."])
+   answer = complete([hello_world, foobar], samples=3, stop_at=["."])
 
 
 - **Prompt management**. You can use functions with the ``@outlines.text.prompt`` decorator. "Prompt functions" use the `Jinja templating language <https://jinja.palletsprojects.com/en/3.1.x/>`_ to render the prompt written in the docstring. We also added a few filters to help with common worflows, like building agents. Of course, for simple prompts, you can also use Python strings directly.


### PR DESCRIPTION
Very nice work! Thanks!
Just started playing with it and got an error with the Hello World example in the documentation. This small modification fixed the issue for me.

Another remark: experimenting in a Jupyter notebook does not work  because of a pb with asynchio, see https://pypi.org/project/nest-asyncio/
The solution proposed there worked for me:
```
import nest_asyncio
nest_asyncio.apply()
```
It would probably be nice to refer to it in the documentation.

I hope this helps.
Best,
Marc