### PR TITLE
Generate a choice between different strings

### DIFF
--- a/outlines/text/generate/__init__.py
+++ b/outlines/text/generate/__init__.py
@@ -1,2 +1,2 @@
 from .continuation import continuation
-from .regex import float, integer, regex
+from .regex import choice, float, integer, regex

--- a/outlines/text/generate/regex.py
+++ b/outlines/text/generate/regex.py
@@ -200,3 +200,9 @@ def float(model, max_tokens: Optional[int] = None):
 
     """
     return Regex(model, r"([+-]?((0|[1-9]+)([.][0-9]*)?)|([.][0-9]+))", max_tokens)
+
+
+def choice(model, choices: List[str], max_tokens: Optional[int] = None):
+    """Choose between different sequences."""
+    regex_str = r"(" + r"|".join(choices) + r")"
+    return Regex(model, regex_str, max_tokens)

--- a/outlines/text/generate/regex.py
+++ b/outlines/text/generate/regex.py
@@ -1,3 +1,4 @@
+import collections
 import math
 from typing import List, Optional, Tuple
 
@@ -38,19 +39,25 @@ class Regex(Continuation):
                 return False
             return True
 
-        pstate_to_vocab = map_partial_states_to_vocab(
+        pstate_to_vocab, paths = map_partial_states_to_vocab(
             list(sorted_vocabulary),
             {"REGEX": self.regex_fsm},
             partial_match_filter,
             final_state_string=model.tokenizer.eos_token,
         )
 
-        # TODO: This check might be a little too strict, because I think that
-        # while some states are made unreachable by a vocabulary (and will not
-        # be present in the following set difference), there could still be
-        # paths to terminal states emanating from the states that are reachable.
-        states_with_transition = {x[1] for x in pstate_to_vocab.keys()}
-        if len(self.regex_fsm.states.difference(states_with_transition)) > 0:
+        # Check whether a terminal path (from the initial state of the FSM to
+        # one of its terminal states) exists, raise an exception otherwise.
+        traversed_states = set()
+        queue = collections.deque([self.regex_fsm.initial])
+        while queue:
+            symbol = queue.popleft()
+            for prev_state in paths["REGEX"][symbol]:
+                if prev_state not in traversed_states:
+                    traversed_states.add(prev_state)
+                    queue.append(prev_state)
+
+        if traversed_states.intersection(self.regex_fsm.finals) == set():
             raise ValueError(
                 "The vocabulary does not allow us to build a sequence that matches the input regex"
             )

--- a/outlines/text/generate/regex.py
+++ b/outlines/text/generate/regex.py
@@ -128,9 +128,7 @@ class Regex(Continuation):
         masks = []
         for pstate in self.pstates:
             mask = torch.full(
-                (len(self.model.tokenizer.vocabulary),),
-                -math.inf,
-                device=self.model.device,
+                (len(self.model.tokenizer.vocabulary),), -math.inf, device=self.device
             )
 
             if pstate[1] > -1:

--- a/tests/text/generate/test_integration_transfomers.py
+++ b/tests/text/generate/test_integration_transfomers.py
@@ -98,6 +98,19 @@ def test_transformers_integration_float():
     float(generated)
 
 
+def test_transformers_integration_choice():
+    rng = torch.Generator()
+    rng.manual_seed(0)
+
+    model_name = "hf-internal-testing/tiny-random-GPTJForCausalLM"
+    model = models.transformers(model_name, device="cpu")
+    prompt = "Write a short sentence "
+    sequence = generate.choice(model, ["test", "choice"])(prompt, rng=rng)
+
+    generated = sequence[len(prompt) :]
+    assert generated == "test" or generated == "choice"
+
+
 def test_transformers_integration_with_pad_token():
     model_name = "hf-internal-testing/tiny-random-XLMRobertaXLForCausalLM"
     model = models.transformers(model_name, device="cpu")

--- a/tests/text/generate/test_regex.py
+++ b/tests/text/generate/test_regex.py
@@ -106,6 +106,35 @@ def test_integer_proposal(input_ids, proposal):
     )
 
 
+def test_choice_proposal():
+    model = Model()
+    generator = generate.choice(model, ["1", "431a", "431A-"])
+    logits = torch.ones(len(model.tokenizer.vocabulary))
+    result = generator.create_proposal(torch.tensor([[]]), logits)
+    assert torch.equal(
+        result,
+        torch.tensor(
+            [[-math.inf, -math.inf, 1.0, -math.inf, 1.0, -math.inf, -math.inf]]
+        ),
+    )
+
+    result = generator.create_proposal(torch.tensor([[4]]), logits)
+    assert torch.equal(
+        result,
+        torch.tensor(
+            [[-math.inf, -math.inf, -math.inf, -math.inf, -math.inf, 1.0, 1.0]]
+        ),
+    )
+
+    result = generator.create_proposal(torch.tensor([[4, 6]]), logits)
+    assert torch.equal(
+        result,
+        torch.tensor(
+            [[-math.inf, 1.0, -math.inf, -math.inf, -math.inf, -math.inf, -math.inf]]
+        ),
+    )
+
+
 @pytest.mark.parametrize(
     "input_ids, proposal",
     [

--- a/tests/text/test_parsing.py
+++ b/tests/text/test_parsing.py
@@ -205,7 +205,9 @@ def test_map_partial_states_to_vocab_python():
 
     vocabulary = ["d", "e", "ef foo", "f ", " ", "1d", "<EOS>"]
 
-    pstate_to_vocab = map_partial_states_to_vocab(vocabulary, symbol_names_and_fsms)
+    pstate_to_vocab, possible_paths = map_partial_states_to_vocab(
+        vocabulary, symbol_names_and_fsms
+    )
 
     assert dict(pstate_to_vocab) == {
         ("__IGNORE_0", 0): {4},
@@ -216,8 +218,11 @@ def test_map_partial_states_to_vocab_python():
         ("DEF", 1): {1, 2},
         ("DEF", 2): {3},
     }
+    assert possible_paths["__IGNORE_0"] == {0: {1}, 1: {1}}
+    assert possible_paths["NAME"] == {0: {1}, 1: {1}}
+    assert possible_paths["DEF"] == {0: {1}, 1: {2, 3}, 2: {3}}
 
-    pstate_to_vocab = map_partial_states_to_vocab(
+    pstate_to_vocab, possible_paths = map_partial_states_to_vocab(
         vocabulary, symbol_names_and_fsms, final_state_string="<EOS>"
     )
 
@@ -239,6 +244,9 @@ def test_map_partial_states_to_vocab_python():
             6,
         },
     }
+    assert possible_paths["__IGNORE_0"] == {0: {1}, 1: {1}}
+    assert possible_paths["NAME"] == {0: {1}, 1: {1}}
+    assert possible_paths["DEF"] == {0: {1}, 1: {2, 3}, 2: {3}}
 
 
 def test_parse_from_partial_match():
@@ -332,7 +340,7 @@ def test_map_partial_states_to_vocab_regex():
             return False
         return True
 
-    pstate_to_vocab = map_partial_states_to_vocab(
+    pstate_to_vocab, possible_paths = map_partial_states_to_vocab(
         vocabulary, {"FLOAT": regex_fsm}, partial_match_filter, "<EOS>"
     )
 
@@ -342,6 +350,7 @@ def test_map_partial_states_to_vocab_regex():
         {1, 5, 8, 12},
         {1, 5, 8},
     ]
+    assert possible_paths["FLOAT"] == {0: {1, 2, 3}, 1: {1, 3}, 2: {3}, 3: {3}}
 
     pstate_to_vocab = {k: tuple(v) for k, v in pstate_to_vocab.items()}
 


### PR DESCRIPTION
Closes #152. I use the `Regex` generation method using a `(choice_1|choice_2|...|choice_n)` regex. This method is equivalent to rejection sampling: draw a token and discard it if it is not on a path that generates either of the choices.

An alternative implementation would be to tokenize the choices, do a forward pass through the model with each and sample from the resulting categorical distribution. However, some strings can be built from different combinations of tokens and we would only be considering one for each stopping sequence.

Unsurprisingly, the check to verify that a sequence can be generated with the vocabulary added in #175 fails. We fix this by checking whether we can build terminal paths with the vocabulary. Closes #184.