### PR TITLE
Convert tokens to strings before partial matching

### DIFF
--- a/outlines/models/tokenizer.py
+++ b/outlines/models/tokenizer.py
@@ -22,3 +22,14 @@ class Tokenizer(Protocol):
     def decode(self, token_ids: NDArray[np.int64]) -> List[str]:
         """Translate an array of token ids to a string or list of strings."""
         ...
+
+    @abstractmethod
+    def convert_token_to_string(self, token: str) -> str:
+        """Convert a token to its equivalent string.
+
+        This is for instance useful for BPE tokenizers where whitespaces are
+        represented by the special characted `Ġ`. This prevents matching a raw
+        token that includes `Ġ` with a string.
+
+        """
+        ...

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -81,6 +81,10 @@ class TransformersTokenizer(Tokenizer):
         text = self.tokenizer.batch_decode(token_ids)
         return text
 
+    def convert_token_to_string(self, token: str) -> str:
+        string = self.tokenizer.convert_tokens_to_string([token])
+        return string
+
 
 def transformers(model_name: str, device: Optional[str] = None, **model_kwargs):
     from transformers import AutoModelForCausalLM

--- a/outlines/text/generate/regex.py
+++ b/outlines/text/generate/regex.py
@@ -26,7 +26,8 @@ class Regex(Continuation):
 
         vocabulary = model.tokenizer.vocabulary
         sorted_vocabulary = [
-            k for k, v in sorted(vocabulary.items(), key=lambda kv: kv[1])
+            model.tokenizer.convert_token_to_string(k)
+            for k, v in sorted(vocabulary.items(), key=lambda kv: kv[1])
         ]
 
         regex_pattern = interegular.parse_pattern(regex_string)

--- a/tests/text/generate/test_regex.py
+++ b/tests/text/generate/test_regex.py
@@ -21,6 +21,9 @@ class Tokenizer:
 
         return decoded
 
+    def convert_token_to_string(self, token):
+        return token
+
 
 class Model:
     tokenizer = Tokenizer()


### PR DESCRIPTION
BPE tokenizers encode whitespaces as a special character `Ġ`, and it is possible that another tokenizer may encode one or several strings as special character(s). Partial matching with the tokens directly thus prevents relevant matches from happening. 

We thus add a `convert_token_to_string` method that converts back these special character to the string they correspond to so we can partially match the corresponding tokens with the regex.

The following snippet illustrates the problem and its solution:

```python
import interegular

from outlines.text.parsing import find_partial_matches
from outlines.models.transformers import transformers

model = transformers("gpt2")

fsm = interegular.parse_pattern("This is a new day").to_fsm()
pmatch = find_partial_matches(fsm, "Ġday")
print(pmatch)
# set()

pmatch = find_partial_matches(fsm, model.tokenizer.convert_token_to_string("Ġday"))
print(pmatch)
# {(3, (13, 14, 15, 16, 17))}
```

Note: we could also iterate over the token ids and use `tokenizer.decode`. This may be simpler than adding a new function, especially since we wouldn't have to sort the vocabulary. But maybe less explicit as this may leave people wondering why we don't use `vocabulary.keys()` directly.