### PR TITLE
Make `transformers` dependency explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,11 @@ import outlines.models as models
 
 model = models.transformers("gpt2")
 
-prompt = labelling("Just awesome", examples)
+prompt = """You are a sentiment-labelling assistant.
+Is the following review positive or negative?
+
+Review: This restaurant is just awesome!
+"""
 answer = generate.choice(model, ["Positive", "Negative"])(prompt)
 ```
 

--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ You can follow [@NormalComputing](https://twitter.com/NormalComputing), [@remilo
 pip install outlines
 ```
 
+The dependencies needed to use models are not installed by default. You will need to run:
+
+- `pip install openai` to be able to use OpenAI [models](https://platform.openai.com/docs/api-reference).
+- `pip install transformers` to be able to use HuggingFace `transformers` [models](https://huggingface.co/models?pipeline_tag=text-generation).
 
 ## Guided generation
 

--- a/outlines/models/transformers.py
+++ b/outlines/models/transformers.py
@@ -87,7 +87,12 @@ class TransformersTokenizer(Tokenizer):
 
 
 def transformers(model_name: str, device: Optional[str] = None, **model_kwargs):
-    from transformers import AutoModelForCausalLM
+    try:
+        from transformers import AutoModelForCausalLM
+    except ImportError:
+        raise ImportError(
+            "The `transformers` library needs to be installed in order to use `transformers` models."
+        )
 
     model = AutoModelForCausalLM.from_pretrained(model_name, **model_kwargs)
     tokenizer = TransformersTokenizer(model_name)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "outlines"
 authors= [{name = "Normal Computing", email = "support@normalcomputing.com"}]
 description = "Probabilistic Generative Model Programming"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 keywords=[
     "normal computing",
     "machine learning",


### PR DESCRIPTION
Made the `transformers` requirement more explicit, by stating it in the README and raising an informative exception when trying to instantiate a model when the library is not installed.Closes #222. 

I also updated `pyproject.toml` to match the required Python version. Closes #234, #219. 

I also fixed an example in the README that was unclear. Closes #218 