### PR TITLE
Fix some typos and language

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ via the next-token logits. It can be used with API-based models as well.
 - [x] 🔥 Fast [JSON generation](#efficient-json-generation-following-a-pydantic-model) following a JSON schema or a Pydantic model
 - [x] 🐍 Interleave completions with loops, conditionals, and custom Python functions
 - [x] 💾 Caching of generations
-- [x] 🤗 Integration with HuggingFace's `transformers` models
+- [x] 🤗 Integration with Hugging Face's `transformers` models
 
 Outlines 〰 has new releases and features coming every week! Make sure to ⭐ star and 👀 watch this repository to stay up to date.
 
@@ -67,7 +67,7 @@ pip install outlines
 The dependencies needed to use models are not installed by default. You will need to run:
 
 - `pip install openai` to be able to use OpenAI [models](https://platform.openai.com/docs/api-reference).
-- `pip install transformers` to be able to use HuggingFace `transformers` [models](https://huggingface.co/models?pipeline_tag=text-generation).
+- `pip install transformers` to be able to use Hugging Face `transformers` [models](https://huggingface.co/models?pipeline_tag=text-generation).
 
 ## Guided generation
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -83,12 +83,12 @@ A toy implementation of an agent (similar to BabyAGI or AutoGPT) with Outlines:
 📜 Features
 -----------
  Simple and powerful prompting primitives based on the Jinja templating engine.
- Integration with OpenAI and HuggingFace models
+ Integration with OpenAI and Hugging Face models
 
 - A powerful domain-specific language to write and render prompts;
 - Interleave completions with loops, conditionals, and custom Python functions;
 - OpenAI integration: language models, embeddings and Dall-E;
-- HuggingFace integration: ``transformers`` and ``diffusers``;
+- Hugging Face integration: ``transformers`` and ``diffusers``;
 - Caching;
 - Sampling multiple sequences;
 - Controlled generation, including multiple choice, type constraints and dynamic stopping.

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -24,10 +24,10 @@ To use OpenAI models you first have to run:
     You also need to set your API credentials by defining the ``OPENAI_API_KEY`` environment variable.
 
 
-HuggingFace
+Hugging Face
 -----------
 
-To use the integrations with HuggingFace's `transformers <https://huggingface.co/docs/transformers/index>`_ and `diffusers <https://huggingface.co/docs/diffusers/index>`_ libraries you first need to run:
+To use the integrations with Hugging Face's `transformers <https://huggingface.co/docs/transformers/index>`_ and `diffusers <https://huggingface.co/docs/diffusers/index>`_ libraries you first need to run:
 
 .. code::
 
@@ -36,7 +36,7 @@ To use the integrations with HuggingFace's `transformers <https://huggingface.co
 
 .. attention::
 
-   HuggingFace models are run locally. Outlines uses the `PyTorch <https://pytorch.org/>`_ versions of the models. Please refer to the `PyTorch documentation <https://pytorch.org/get-started/locally/>`_ for questions related to **GPU support**.
+   Hugging Face models are run locally. Outlines uses the `PyTorch <https://pytorch.org/>`_ versions of the models. Please refer to the `PyTorch documentation <https://pytorch.org/get-started/locally/>`_ for questions related to **GPU support**.
 
 The integration is fairly basic for now, and if you have specific performance needs please `open an issue <https://github.com/normal-computing/outlines/issues>`_
 

--- a/docs/source/overview.rst
+++ b/docs/source/overview.rst
@@ -22,7 +22,7 @@ Here is a simple Outlines program that highlights some of its key features:
 
 
 - **Prompt management**. You can use functions with the ``@outlines.text.prompt`` decorator. "Prompt functions" use the `Jinja templating language <https://jinja.palletsprojects.com/en/3.1.x/>`_ to render the prompt written in the docstring. We also added a few filters to help with common worflows, like building agents. Of course, for simple prompts, you can also use Python strings directly.
-- **Generative model integration**. You can use text completion models from OpenAI and HuggingFace, but models are not limited to text.
+- **Generative model integration**. You can use text completion models from OpenAI and Hugging Face, but models are not limited to text.
 - **Controlled generation**. The ``stop_at`` keyword arguments allows to define when the generation should be stopped. Outlines includes more options to control the generation; these happen on a token basis, saving time and costs.
 - **Sampling**. Outlines exclusively generates sequences using sampling. You can generate many samples with one call.
 - **Batching**. Models can take a list of prompt as input and generate completions in parallel.

--- a/docs/source/reference/multimodel.rst
+++ b/docs/source/reference/multimodel.rst
@@ -24,10 +24,10 @@ It is also possible to use DALL-E to generate images:
    generate = models.image_generation.openai("dall-e")
 
 
-HuggingFace
+Hugging Face
 -----------
 
-Outlines can call models from HuggingFace's `transformers` and `diffusers` libraries. The models are then run locally.
+Outlines can call models from Hugging Face's `transformers` and `diffusers` libraries. The models are then run locally.
 
 .. code::
 

--- a/outlines/models/__init__.py
+++ b/outlines/models/__init__.py
@@ -1,4 +1,4 @@
-"""Module that contains all the models integated in outlines.
+"""Module that contains all the models integrated in outlines.
 
 We group the models in submodules by provider instead of theme (completion, chat
 completion, diffusers, etc.) and use routing functions everywhere else in the

--- a/outlines/models/hf_diffusers.py
+++ b/outlines/models/hf_diffusers.py
@@ -1,4 +1,4 @@
-"""Integration with HuggingFace's `diffusers` library."""
+"""Integration with Hugging Face's `diffusers` library."""
 import functools
 from typing import List, Union
 
@@ -14,7 +14,7 @@ def HuggingFaceDiffuser(model_name: str) -> PILImage:
     Parameters
     ----------
     model_name: str
-        The name of the model as listed on HuggingFace's models page.
+        The name of the model as listed on Hugging Face's models page.
 
     """
 

--- a/outlines/models/hf_transformers.py
+++ b/outlines/models/hf_transformers.py
@@ -1,4 +1,4 @@
-"""Integration with HuggingFace's `transformers` library."""
+"""Integration with Hugging Face's `transformers` library."""
 import functools
 from typing import TYPE_CHECKING, Callable, Dict, List, Optional, Tuple, Union
 
@@ -21,7 +21,7 @@ def HuggingFaceCompletion(
 
     You should have the `torch` and `transformers` packages installed. First
     execution may take a while since the pre-trained weights will be downloaded.
-    Available models are listed on `HuggingFace's model page <https://huggingface.co/models>`_.
+    Available models are listed on `Hugging Face's model page <https://huggingface.co/models>`_.
 
     Note
     ----
@@ -33,7 +33,7 @@ def HuggingFaceCompletion(
     Parameters
     ----------
     model_name: str
-        The name of the model as listed on HuggingFace's models page.
+        The name of the model as listed on Hugging Face's models page.
     max_tokens
         The maximum number of tokens to generate.
     temperature

--- a/outlines/models/hf_transformers.py
+++ b/outlines/models/hf_transformers.py
@@ -26,7 +26,7 @@ def HuggingFaceCompletion(
     Note
     ----
 
-    To my knowledge `tranformers` does not simply allow to stop the generation
+    To my knowledge `transformers` does not simply allow to stop the generation
     after a given sequence has been generated. We will need to implement this
     manually for this integration to have the same features as `OpenAICompletion`.
 

--- a/outlines/vectors/retrieval.py
+++ b/outlines/vectors/retrieval.py
@@ -7,7 +7,7 @@ import scipy.spatial as spatial
 def cosine_similarity(
     vectors: Sequence[np.ndarray], query: np.ndarray, k: int = 1
 ) -> List[np.ndarray]:
-    """Use cosine similarity to retrieve the `top_n` closest vectors to the query.
+    """Use cosine similarity to retrieve the top `k` closest vectors to the query.
 
     Be mindful that Scipy computes the cosine distance, defined as one minus the cosine
     similarity.
@@ -23,5 +23,5 @@ def cosine_similarity(
 
     """
     similarities = [spatial.distance.cosine(v, query) for v in vectors]
-    top_n_indices = np.argsort(similarities)[:k]
-    return top_n_indices
+    top_k_indices = np.argsort(similarities)[:k]
+    return top_k_indices


### PR DESCRIPTION
Hey, some small things I saw here, feel free to cherry-pick/discuss.

- [x] Fixes a typo in the file `outlines/models/__init__.py`
- [x] Fixes a typo in the file `outlines/models/hf_transformers.py`
- [x] Fixes mismatched language in the `outlines/vectors/retrieval.py` file between the `k` argument and the phrase `top_n`
- [x] Uses "Hugging Face" instead of "HuggingFace" outside of code, in line with that brand.
