### PR TITLE
Fix some typos/language in `regex` and `sequence`

### DIFF
--- a/README.md
+++ b/README.md
@@ -383,7 +383,7 @@ Do not hesitate to open a draft PR before your contribution is ready, especially
 - [Pick the odd one out](https://github.com/normal-computing/outlines/blob/main/examples/pick_odd_one_out.py)
 - [Meta prompting](https://github.com/normal-computing/outlines/blob/main/examples/meta_prompting.py)
 - [ReAct](https://github.com/normal-computing/outlines/blob/main/examples/react.py)
-- [Generate code to solve math problems](https://github.com/normal-computing/outlines/blob/main/examples/dust/math-generate-code.py)
+- [Generate code to solve math problems](https://github.com/normal-computing/outlines/blob/main/examples/math_generate_code.py)
 - [BabyAGI](https://github.com/normal-computing/outlines/blob/main/examples/babyagi.py)
 - [Uncertainty](https://github.com/normal-computing/outlines/blob/main/examples/sampling.ipynb)
 - [Simulation-based inference](https://github.com/normal-computing/outlines/blob/main/examples/simulation_based_inference.ipynb)

--- a/outlines/text/generate/continuation.py
+++ b/outlines/text/generate/continuation.py
@@ -96,7 +96,7 @@ def continuation(
     Parameters
     ----------
     model
-        The model to use to computes the next-token logits.
+        The language model to use to compute the next-token logits.
     max_tokens
         The maximum number of tokens to generate.
     stop

--- a/outlines/text/generate/regex.py
+++ b/outlines/text/generate/regex.py
@@ -153,7 +153,7 @@ def regex(model, regex_string: str, max_tokens: Optional[int] = None):
     Parameters
     ----------
     model
-        The model to use to compute the next-token logits.
+        The language model to use to compute the next-token logits.
     regex_string
         The regular expression that generated expressions must match.
     max_tokens
@@ -173,7 +173,7 @@ def integer(model, max_tokens: Optional[int] = None):
     Parameters
     ----------
     model
-        The model to use to compute the next-token logits.
+        The language model to use to compute the next-token logits.
     max_tokens
         The maximum number of tokens to generate.
 
@@ -191,7 +191,7 @@ def float(model, max_tokens: Optional[int] = None):
     Parameters
     ----------
     model
-        The model to use to compute the next-token logits.
+        The language model to use to compute the next-token logits.
     max_tokens
         The maximum number of tokens to generate.
 
@@ -211,7 +211,7 @@ def json(model, schema: Union[str, BaseModel], max_tokens: Optional[int] = None)
     Parameters
     ---------
     model
-        The model to use to compute the next-token logits.
+        The language model to use to compute the next-token logits.
     schema
         The JSON schema or Pydantic model that guides the generation.
     max_tokens

--- a/outlines/text/generate/regex.py
+++ b/outlines/text/generate/regex.py
@@ -74,7 +74,7 @@ class Regex(Continuation):
     def create_proposal(
         self, generated_token_ids: torch.LongTensor, logits: torch.DoubleTensor
     ) -> torch.DoubleTensor:
-        """Modify the next-token logits so that only integers can be generated.
+        """Modify the next-token logits so that only valid tokens can be generated.
 
         Parameters
         ----------
@@ -97,16 +97,16 @@ class Regex(Continuation):
                 generated_token_ids,
                 self.pstates,
             ):
-                # Get the tokens we haven't already processed
+                # Get the tokens we haven't already processed,
                 readable_tokens = token_seq[last_token_idx:]
-                # excluding any EOS tokens
+                # excluding any EOS tokens.
                 not_eos_mask = [
                     tk != self.model.tokenizer.eos_token_id for tk in readable_tokens
                 ]
                 readable_tokens = readable_tokens[not_eos_mask]
                 if len(readable_tokens) > 0:
                     # If we previously ended with an EOS, we shouldn't be
-                    # getting/sampling any more non-EOS tokens
+                    # getting/sampling any more non-EOS tokens.
                     assert last_fsm_state > -1
 
                     sequence = self.model.tokenizer.decode(readable_tokens)
@@ -153,9 +153,9 @@ def regex(model, regex_string: str, max_tokens: Optional[int] = None):
     Parameters
     ----------
     model
-        The model to use to computes the next-token logits.
-    regex
-        The regular expression generated expressions must match.
+        The model to use to compute the next-token logits.
+    regex_string
+        The regular expression that generated expressions must match.
     max_tokens
         The maximum number of tokens to generate.
 
@@ -173,9 +173,7 @@ def integer(model, max_tokens: Optional[int] = None):
     Parameters
     ----------
     model
-        The model to use to computes the next-token logits.
-    regex
-        The regular expression generated expressions must match.
+        The model to use to compute the next-token logits.
     max_tokens
         The maximum number of tokens to generate.
 
@@ -193,9 +191,7 @@ def float(model, max_tokens: Optional[int] = None):
     Parameters
     ----------
     model
-        The model to use to computes the next-token logits.
-    regex
-        The regular expression generated expressions must match.
+        The model to use to compute the next-token logits.
     max_tokens
         The maximum number of tokens to generate.
 
@@ -210,16 +206,16 @@ def choice(model, choices: List[str], max_tokens: Optional[int] = None):
 
 
 def json(model, schema: Union[str, BaseModel], max_tokens: Optional[int] = None):
-    """Generate a text sequence that follows a JSON schema.
+    """Generate a text sequence that follows a JSON schema or Pydantic model.
 
     Parameters
     ---------
     model
-        The model to use to computes the next-token logits.
+        The model to use to compute the next-token logits.
     schema
-        The JSON schema, or Pydantic model, that guides the generation.
+        The JSON schema or Pydantic model that guides the generation.
     max_tokens
-        The maximum number of tokens to generate at each step.
+        The maximum number of tokens to generate.
 
     """
     if isinstance(schema, type(BaseModel)):

--- a/outlines/text/generate/sequence.py
+++ b/outlines/text/generate/sequence.py
@@ -57,7 +57,7 @@ class Sequence:
         Parameters
         ----------
         rng
-            NumPy random number Generator instance
+            NumPy random number Generator instance.
         num_prompt_tokens
             The number of tokens in the prompt.
         token_ids
@@ -82,10 +82,10 @@ class Sequence:
         probs = self.create_proposal(token_ids[:, num_prompt_tokens:], probs)
         probs = torch.nn.functional.softmax(probs, dim=-1)
 
-        # Sample `samples`-many new tokens
+        # Sample `samples`-many new tokens.
         next_token_ids = vectorized_random_choice(rng, probs, samples)
 
-        # Add the missing `num_tokens` and `num_sample` dimensions
+        # Add the missing `num_tokens` and `num_sample` dimensions.
         next_token_ids = torch.unsqueeze(next_token_ids, -1)
         token_ids = torch.unsqueeze(token_ids, 0)
 


### PR DESCRIPTION
Please correct me if I'm wrong about any of the below! But I noticed a few more things that seem mismatched in comments.

- [x] Fixed a typo in `regex/create_proposal` implying that this method is only for integer generation, whereas it seems clear that this method is used for all schemas.
- [x] Fixed some typos where argument names were mismatched or nonexistent in the actual function code.
- [x] Fixed some typos for overall language (e.g. "used to compute" instead of "used to computes") and to clarify potentially confusing comments.
- [x] Fixed a broken link in `README.md`